### PR TITLE
🔥 v0.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,12 +80,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y chromium-browser
           echo "PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser" >> $GITHUB_ENV
-      # Exclude the private admin-ui (Next.js dashboard) from the cross-OS test
-      # matrix: it has no test suite and its only native dep (better-sqlite3)
-      # lacks prebuilt binaries for some Node/OS combos (e.g. Node 20 + Windows),
-      # forcing a source build that needs a toolchain the runner doesn't have.
-      # The dedicated Build job still builds admin-ui on Linux, where prebuilds exist.
-      - run: pnpm install --frozen-lockfile --filter '!@lov3kaizen/agentsea-admin-ui'
+      - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
       # Skip Puppeteer Chrome download - use system Chromium instead

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y chromium-browser
           echo "PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser" >> $GITHUB_ENV
-      - run: pnpm install --frozen-lockfile
+      # Exclude the private admin-ui (Next.js dashboard) from the cross-OS test
+      # matrix: it has no test suite and its only native dep (better-sqlite3)
+      # lacks prebuilt binaries for some Node/OS combos (e.g. Node 20 + Windows),
+      # forcing a source build that needs a toolchain the runner doesn't have.
+      # The dedicated Build job still builds admin-ui on Linux, where prebuilds exist.
+      - run: pnpm install --frozen-lockfile --filter '!@lov3kaizen/agentsea-admin-ui'
       - run: pnpm test
 
   coverage:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsea",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "AgentSea - Production-ready ADK for building agentic AI applications in Node.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
       "ajv@6": "^6.14.0",
       "ajv@8": "^8.18.0",
       "basic-ftp": ">=5.3.1",
+      "better-sqlite3": "11.10.0",
       "brace-expansion@1": "^1.1.13",
       "brace-expansion@2": "^2.0.3",
       "esbuild@<0.25.0": ">=0.25.0",
@@ -90,11 +91,11 @@
       "js-yaml@4": "^4.1.1",
       "lodash": "^4.18.0",
       "mdast-util-to-hast@13": "^13.2.1",
+      "minimatch@10": "^10.2.3",
       "minimatch@3": "^3.1.4",
       "minimatch@5": "^5.1.8",
       "minimatch@7": "^7.4.8",
       "minimatch@9": "^9.0.7",
-      "minimatch@10": "^10.2.3",
       "mongoose@8": "^8.22.1",
       "picomatch@2": "^2.3.2",
       "picomatch@4": "^4.0.4",
@@ -110,9 +111,9 @@
       "undici@7": "^7.24.0",
       "uuid": ">=11.1.1",
       "validator": "^13.15.22",
+      "vite@<6.4.2": "^6.4.2",
       "ws@8": "^8.20.1",
-      "yaml@2": "^2.8.3",
-      "vite@<6.4.2": "^6.4.2"
+      "yaml@2": "^2.8.3"
     }
   }
 }

--- a/packages/admin-ui/drizzle.config.ts
+++ b/packages/admin-ui/drizzle.config.ts
@@ -1,10 +1,10 @@
-import type { Config } from 'drizzle-kit';
+import { defineConfig } from 'drizzle-kit';
 
-export default {
+export default defineConfig({
   schema: './lib/db/schema.ts',
   out: './drizzle',
-  driver: 'better-sqlite',
+  dialect: 'sqlite',
   dbCredentials: {
     url: process.env.DATABASE_PATH || '.agentsea/admin.db',
   },
-} satisfies Config;
+});

--- a/packages/admin-ui/drizzle/0001_classy_turbo.sql
+++ b/packages/admin-ui/drizzle/0001_classy_turbo.sql
@@ -1,0 +1,21 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_agents` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`system_prompt` text,
+	`provider` text DEFAULT 'anthropic' NOT NULL,
+	`model` text DEFAULT 'claude-opus-4-8' NOT NULL,
+	`temperature` real DEFAULT 0.7,
+	`max_tokens` integer DEFAULT 4096,
+	`memory_type` text DEFAULT 'buffer',
+	`memory_config` text,
+	`tools` text,
+	`created_at` integer DEFAULT (unixepoch()),
+	`updated_at` integer DEFAULT (unixepoch())
+);
+--> statement-breakpoint
+INSERT INTO `__new_agents`("id", "name", "description", "system_prompt", "provider", "model", "temperature", "max_tokens", "memory_type", "memory_config", "tools", "created_at", "updated_at") SELECT "id", "name", "description", "system_prompt", "provider", "model", "temperature", "max_tokens", "memory_type", "memory_config", "tools", "created_at", "updated_at" FROM `agents`;--> statement-breakpoint
+DROP TABLE `agents`;--> statement-breakpoint
+ALTER TABLE `__new_agents` RENAME TO `agents`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/packages/admin-ui/drizzle/meta/0001_snapshot.json
+++ b/packages/admin-ui/drizzle/meta/0001_snapshot.json
@@ -1,6 +1,8 @@
 {
   "version": "6",
   "dialect": "sqlite",
+  "id": "f4bdf7c1-78aa-4b90-ad15-2ac2e7acb449",
+  "prevId": "934b2129-d8b9-494b-b778-44be6fa1df10",
   "tables": {
     "agents": {
       "name": "agents",
@@ -47,7 +49,7 @@
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false,
-          "default": "'claude-3-5-sonnet-20241022'"
+          "default": "'claude-opus-4-8'"
         },
         "temperature": {
           "name": "temperature",
@@ -205,20 +207,20 @@
         "executions_workflow_id_workflows_id_fk": {
           "name": "executions_workflow_id_workflows_id_fk",
           "tableFrom": "executions",
-          "columnsFrom": ["workflow_id"],
           "tableTo": "workflows",
+          "columnsFrom": ["workflow_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         },
         "executions_agent_id_agents_id_fk": {
           "name": "executions_agent_id_agents_id_fk",
           "tableFrom": "executions",
-          "columnsFrom": ["agent_id"],
           "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
           "columnsTo": ["id"],
-          "onUpdate": "no action",
-          "onDelete": "no action"
+          "onDelete": "no action",
+          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
@@ -516,12 +518,14 @@
       "checkConstraints": {}
     }
   },
+  "views": {},
   "enums": {},
   "_meta": {
+    "schemas": {},
     "tables": {},
     "columns": {}
   },
-  "id": "934b2129-d8b9-494b-b778-44be6fa1df10",
-  "prevId": "00000000-0000-0000-0000-000000000000",
-  "views": {}
+  "internal": {
+    "indexes": {}
+  }
 }

--- a/packages/admin-ui/drizzle/meta/_journal.json
+++ b/packages/admin-ui/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1762519179430,
       "tag": "0000_reflective_killmonger",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1781270087021,
+      "tag": "0001_classy_turbo",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -36,7 +36,7 @@
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@xyflow/react": "^12.0.0",
-    "better-sqlite3": "^12.4.1",
+    "better-sqlite3": "^11.10.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "test": "echo 'No tests configured for admin-ui package'",
     "type-check": "tsc --noEmit",
-    "db:generate": "drizzle-kit generate:sqlite",
+    "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx lib/db/migrate.ts",
     "db:studio": "drizzle-kit studio"
   },

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -36,7 +36,7 @@
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@xyflow/react": "^12.0.0",
-    "better-sqlite3": "^9.4.0",
+    "better-sqlite3": "^12.4.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
@@ -52,7 +52,7 @@
     "zustand": "^4.5.0"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.9",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.11.0",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-admin-ui",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Web-based admin UI for AgentSea SDK - Visual workflow builder and agent management",
   "private": true,
   "scripts": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-analytics",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Conversation analytics for AI agents - intent classification, flow analysis, sentiment tracking, and insights",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "CLI tool for AgentSea ADK - Build and orchestrate AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "AgentSea - Unite and orchestrate AI agents. A production-ready ADK for building agentic AI applications with multi-provider support.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/costs/package.json
+++ b/packages/costs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-costs",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "AI cost management platform with real-time tracking, budget enforcement, and optimization",
   "type": "module",
   "main": "./dist/index.js",
@@ -59,8 +59,8 @@
     "vitest": "^3.2.6"
   },
   "peerDependencies": {
-    "@nestjs/common": "^10.0.0",
-    "@nestjs/core": "^10.0.0",
+    "@nestjs/common": "^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^10.0.0 || ^11.0.0",
     "better-sqlite3": "^11.0.0",
     "pg": "^8.0.0",
     "stripe": "^17.0.0"

--- a/packages/crews/package.json
+++ b/packages/crews/package.json
@@ -48,8 +48,8 @@
   },
   "peerDependencies": {
     "@lov3kaizen/agentsea-core": "workspace:*",
-    "@nestjs/common": "^10.0.0",
-    "@nestjs/core": "^10.0.0"
+    "@nestjs/common": "^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^10.0.0 || ^11.0.0"
   },
   "peerDependenciesMeta": {
     "@nestjs/common": {

--- a/packages/guardrails/package.json
+++ b/packages/guardrails/package.json
@@ -58,8 +58,8 @@
     "vitest": "^3.2.6"
   },
   "peerDependencies": {
-    "@nestjs/common": "^10.0.0",
-    "@nestjs/core": "^10.0.0",
+    "@nestjs/common": "^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^10.0.0 || ^11.0.0",
     "@lov3kaizen/agentsea-core": "workspace:*"
   },
   "peerDependenciesMeta": {

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-nestjs",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "NestJS integration for AgentSea - Unite and orchestrate AI agents in your NestJS applications",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -27,10 +27,10 @@
   "dependencies": {
     "@lov3kaizen/agentsea-types": "workspace:*",
     "@lov3kaizen/agentsea-core": "workspace:*",
-    "@nestjs/common": "^10.3.0",
-    "@nestjs/core": "^10.3.0",
-    "@nestjs/websockets": "^10.3.0",
-    "@nestjs/platform-socket.io": "^10.3.0",
+    "@nestjs/common": "^11.1.26",
+    "@nestjs/core": "^11.1.26",
+    "@nestjs/websockets": "^11.1.26",
+    "@nestjs/platform-socket.io": "^11.1.26",
     "class-validator": "^0.14.1",
     "class-transformer": "^0.5.1",
     "reflect-metadata": "^0.2.1",
@@ -45,8 +45,8 @@
     "vitest": "^3.2.6"
   },
   "peerDependencies": {
-    "@nestjs/common": "^10.0.0",
-    "@nestjs/core": "^10.0.0"
+    "@nestjs/common": "^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^10.0.0 || ^11.0.0"
   },
   "keywords": [
     "agentsea",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-react",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "React components for rendering AgentSea agent responses with formatting support",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/structured/package.json
+++ b/packages/structured/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-structured",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "TypeScript-native structured output framework - Zod schema enforcement for LLM responses",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/surf/package.json
+++ b/packages/surf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-surf",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Surf - Computer-use agent for AgentSea. Control desktop environments through screen capture, mouse, and keyboard actions using Claude's vision capabilities.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -45,10 +45,10 @@
     "vitest": "^3.2.6"
   },
   "peerDependencies": {
-    "@nestjs/common": "^10.0.0",
-    "@nestjs/core": "^10.0.0",
-    "@nestjs/websockets": "^10.0.0",
-    "@nestjs/platform-socket.io": "^10.0.0",
+    "@nestjs/common": "^10.0.0 || ^11.0.0",
+    "@nestjs/core": "^10.0.0 || ^11.0.0",
+    "@nestjs/websockets": "^10.0.0 || ^11.0.0",
+    "@nestjs/platform-socket.io": "^10.0.0 || ^11.0.0",
     "puppeteer-core": "^21.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-types",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Type definitions for AgentSea ADK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,11 +422,11 @@ importers:
         specifier: ^0.104.1
         version: 0.104.1(zod@3.25.76)
       '@nestjs/common':
-        specifier: ^10.0.0
-        version: 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^10.0.0 || ^11.0.0
+        version: 11.1.26(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core':
-        specifier: ^10.0.0
-        version: 10.4.20(@nestjs/common@10.4.20)(@nestjs/websockets@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^10.0.0 || ^11.0.0
+        version: 11.1.26(@nestjs/common@11.1.26)(@nestjs/websockets@11.1.26)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       croner:
         specifier: ^9.0.0
         version: 9.1.0
@@ -483,11 +483,11 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@nestjs/common':
-        specifier: ^10.0.0
-        version: 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^10.0.0 || ^11.0.0
+        version: 11.1.26(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core':
-        specifier: ^10.0.0
-        version: 10.4.20(@nestjs/common@10.4.20)(@nestjs/websockets@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^10.0.0 || ^11.0.0
+        version: 11.1.26(@nestjs/common@11.1.26)(@nestjs/websockets@11.1.26)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       eventemitter3:
         specifier: ^5.0.0
         version: 5.0.1
@@ -696,11 +696,11 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@nestjs/common':
-        specifier: ^10.0.0
-        version: 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^10.0.0 || ^11.0.0
+        version: 11.1.26(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core':
-        specifier: ^10.0.0
-        version: 10.4.20(@nestjs/common@10.4.20)(@nestjs/websockets@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^10.0.0 || ^11.0.0
+        version: 11.1.26(@nestjs/common@11.1.26)(@nestjs/websockets@11.1.26)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       lru-cache:
         specifier: ^10.0.0
         version: 10.4.3
@@ -864,17 +864,17 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@nestjs/common':
-        specifier: ^10.3.0
-        version: 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^11.1.26
+        version: 11.1.26(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core':
-        specifier: ^10.3.0
-        version: 10.4.20(@nestjs/common@10.4.20)(@nestjs/websockets@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^11.1.26
+        version: 11.1.26(@nestjs/common@11.1.26)(@nestjs/websockets@11.1.26)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-socket.io':
-        specifier: ^10.3.0
-        version: 10.4.20(@nestjs/common@10.4.20)(@nestjs/websockets@10.4.20)(rxjs@7.8.2)
+        specifier: ^11.1.26
+        version: 11.1.26(@nestjs/common@11.1.26)(@nestjs/websockets@11.1.26)(rxjs@7.8.2)
       '@nestjs/websockets':
-        specifier: ^10.3.0
-        version: 10.4.20(@nestjs/common@10.4.20)(@nestjs/core@10.4.20)(@nestjs/platform-socket.io@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^11.1.26
+        version: 11.1.26(@nestjs/common@11.1.26)(@nestjs/core@11.1.26)(@nestjs/platform-socket.io@11.1.26)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -1080,17 +1080,17 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@nestjs/common':
-        specifier: ^10.0.0
-        version: 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^10.0.0 || ^11.0.0
+        version: 11.1.26(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core':
-        specifier: ^10.0.0
-        version: 10.4.20(@nestjs/common@10.4.20)(@nestjs/websockets@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^10.0.0 || ^11.0.0
+        version: 11.1.26(@nestjs/common@11.1.26)(@nestjs/websockets@11.1.26)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-socket.io':
-        specifier: ^10.0.0
-        version: 10.4.20(@nestjs/common@10.4.20)(@nestjs/websockets@10.4.20)(rxjs@7.8.2)
+        specifier: ^10.0.0 || ^11.0.0
+        version: 11.1.26(@nestjs/common@11.1.26)(@nestjs/websockets@11.1.26)(rxjs@7.8.2)
       '@nestjs/websockets':
-        specifier: ^10.0.0
-        version: 10.4.20(@nestjs/common@10.4.20)(@nestjs/core@10.4.20)(@nestjs/platform-socket.io@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+        specifier: ^10.0.0 || ^11.0.0
+        version: 11.1.26(@nestjs/common@11.1.26)(@nestjs/core@11.1.26)(@nestjs/platform-socket.io@11.1.26)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       puppeteer-core:
         specifier: ^21.0.0
         version: 21.11.0
@@ -3591,11 +3591,11 @@ packages:
     dev: true
     optional: true
 
-  /@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2):
-    resolution: {integrity: sha512-hxJxZF7jcKGuUzM9EYbuES80Z/36piJbiqmPy86mk8qOn5gglFebBTvcx7PWVbRNSb4gngASYnefBj/Y2HAzpQ==}
+  /@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2):
+    resolution: {integrity: sha512-0VARQyzuGbprvjO+slWq9Jtj1P0jYCSKAUSv9LWFNWD39ZbDzXXM1pMs35kReVXwchra0urMfTQxw4uAOfdSzA==}
     peerDependencies:
-      class-transformer: '*'
-      class-validator: '*'
+      class-transformer: '>=0.4.1'
+      class-validator: '>=0.13.2'
       reflect-metadata: ^0.1.12 || ^0.2.0
       rxjs: ^7.1.0
     peerDependenciesMeta:
@@ -3608,6 +3608,7 @@ packages:
       class-validator: 0.14.2
       file-type: 21.3.4
       iterare: 1.2.1
+      load-esm: 1.0.3
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
       tslib: 2.8.1
@@ -3616,14 +3617,14 @@ packages:
       - supports-color
     dev: false
 
-  /@nestjs/core@10.4.20(@nestjs/common@10.4.20)(@nestjs/websockets@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2):
-    resolution: {integrity: sha512-kRdtyKA3+Tu70N3RQ4JgmO1E3LzAMs/eppj7SfjabC7TgqNWoS4RLhWl4BqmsNVmjj6D5jgfPVtHtgYkU3AfpQ==}
-    requiresBuild: true
+  /@nestjs/core@11.1.26(@nestjs/common@11.1.26)(@nestjs/websockets@11.1.26)(reflect-metadata@0.2.2)(rxjs@7.8.2):
+    resolution: {integrity: sha512-K45zUwYpowEsVqm8qNIzsMcl4LJev0MK9zVhDnmym7YRTJ2/caslqVeKYhPRd5+Fh81IkvWUVu6vEo46uZ5mgQ==}
+    engines: {node: '>= 20'}
     peerDependencies:
-      '@nestjs/common': ^10.0.0
-      '@nestjs/microservices': ^10.0.0
-      '@nestjs/platform-express': ^10.0.0
-      '@nestjs/websockets': ^10.0.0
+      '@nestjs/common': ^11.0.0
+      '@nestjs/microservices': ^11.0.0
+      '@nestjs/platform-express': ^11.0.0
+      '@nestjs/websockets': ^11.0.0
       reflect-metadata: ^0.1.12 || ^0.2.0
       rxjs: ^7.1.0
     peerDependenciesMeta:
@@ -3634,31 +3635,28 @@ packages:
       '@nestjs/websockets':
         optional: true
     dependencies:
-      '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/websockets': 10.4.20(@nestjs/common@10.4.20)(@nestjs/core@10.4.20)(@nestjs/platform-socket.io@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nuxtjs/opencollective': 0.3.2
+      '@nestjs/common': 11.1.26(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/websockets': 11.1.26(@nestjs/common@11.1.26)(@nestjs/core@11.1.26)(@nestjs/platform-socket.io@11.1.26)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
-      path-to-regexp: 3.3.0
+      path-to-regexp: 8.4.2
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
       tslib: 2.8.1
       uid: 2.0.2
-    transitivePeerDependencies:
-      - encoding
     dev: false
 
-  /@nestjs/platform-socket.io@10.4.20(@nestjs/common@10.4.20)(@nestjs/websockets@10.4.20)(rxjs@7.8.2):
-    resolution: {integrity: sha512-8wqJ7kJnvRC6T1o1U3NNnuzjaMJU43R4hvzKKba7GSdMN6j2Jfzz/vq5gHDx9xbXOAmfsc9bvaIiZegXxvHoJA==}
+  /@nestjs/platform-socket.io@11.1.26(@nestjs/common@11.1.26)(@nestjs/websockets@11.1.26)(rxjs@7.8.2):
+    resolution: {integrity: sha512-uuBZI+65OcG0K+lTv8CCuvaQi5/tb2EBhbObnVeSjb7oIxiynwULhdJiynbFfotUKv4PebDPDIhByePCjOnfAQ==}
     peerDependencies:
-      '@nestjs/common': ^10.0.0
-      '@nestjs/websockets': ^10.0.0
+      '@nestjs/common': ^11.0.0
+      '@nestjs/websockets': ^11.0.0
       rxjs: ^7.1.0
     dependencies:
-      '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/websockets': 10.4.20(@nestjs/common@10.4.20)(@nestjs/core@10.4.20)(@nestjs/platform-socket.io@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.26(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/websockets': 11.1.26(@nestjs/common@11.1.26)(@nestjs/core@11.1.26)(@nestjs/platform-socket.io@11.1.26)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       rxjs: 7.8.2
-      socket.io: 4.8.1
+      socket.io: 4.8.3
       tslib: 2.8.1
     transitivePeerDependencies:
       - bufferutil
@@ -3666,21 +3664,21 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@nestjs/websockets@10.4.20(@nestjs/common@10.4.20)(@nestjs/core@10.4.20)(@nestjs/platform-socket.io@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2):
-    resolution: {integrity: sha512-tafsPPvQfAXc+cfxvuRDzS5V+Ixg8uVJq8xSocU24yVl/Xp6ajmhqiGiaVjYOX8mXY0NV836QwEZxHF7WvKHSw==}
+  /@nestjs/websockets@11.1.26(@nestjs/common@11.1.26)(@nestjs/core@11.1.26)(@nestjs/platform-socket.io@11.1.26)(reflect-metadata@0.2.2)(rxjs@7.8.2):
+    resolution: {integrity: sha512-7ZZrVsaYVptAVL5J6eYIg3UMwlVwE1Yh/OpS6ieVv7DtFHKNNufHdktfysRavsHWCdIYNg6+ty0SGI7doJUwog==}
     peerDependencies:
-      '@nestjs/common': ^10.0.0
-      '@nestjs/core': ^10.0.0
-      '@nestjs/platform-socket.io': ^10.0.0
+      '@nestjs/common': ^11.0.0
+      '@nestjs/core': ^11.0.0
+      '@nestjs/platform-socket.io': ^11.0.0
       reflect-metadata: ^0.1.12 || ^0.2.0
       rxjs: ^7.1.0
     peerDependenciesMeta:
       '@nestjs/platform-socket.io':
         optional: true
     dependencies:
-      '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 10.4.20(@nestjs/common@10.4.20)(@nestjs/websockets@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/platform-socket.io': 10.4.20(@nestjs/common@10.4.20)(@nestjs/websockets@10.4.20)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.26(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.26(@nestjs/common@11.1.26)(@nestjs/websockets@11.1.26)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/platform-socket.io': 11.1.26(@nestjs/common@11.1.26)(@nestjs/websockets@11.1.26)(rxjs@7.8.2)
       iterare: 1.2.1
       object-hash: 3.0.0
       reflect-metadata: 0.2.2
@@ -3798,18 +3796,6 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
     dev: true
-
-  /@nuxtjs/opencollective@0.3.2:
-    resolution: {integrity: sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==}
-    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
-    hasBin: true
-    dependencies:
-      chalk: 4.1.2
-      consola: 2.15.3
-      node-fetch: 2.7.0(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
-    dev: false
 
   /@opentelemetry/api-logs@0.217.0:
     resolution: {integrity: sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A==}
@@ -7907,10 +7893,6 @@ packages:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
     dev: true
 
-  /consola@2.15.3:
-    resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
-    dev: false
-
   /consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -10845,6 +10827,11 @@ packages:
       wrap-ansi: 9.0.2
     dev: true
 
+  /load-esm@1.0.3:
+    resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
+    engines: {node: '>=13.2.0'}
+    dev: false
+
   /load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -12201,8 +12188,8 @@ packages:
       minipass: 7.1.2
     dev: true
 
-  /path-to-regexp@3.3.0:
-    resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
+  /path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
     dev: false
 
   /path-type@4.0.0:
@@ -13468,6 +13455,23 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  /socket.io@4.8.3:
+    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
+    engines: {node: '>=10.2.0'}
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.5
+      debug: 4.4.3
+      engine.io: 6.6.4
+      socket.io-adapter: 2.5.5
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
 
   /socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,8 +164,8 @@ importers:
         specifier: ^12.0.0
         version: 12.9.2(@types/react@18.3.26)(react-dom@18.3.1)(react@18.3.1)
       better-sqlite3:
-        specifier: ^9.4.0
-        version: 9.6.0
+        specifier: ^12.4.1
+        version: 12.10.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -174,7 +174,7 @@ importers:
         version: 2.1.1
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@9.6.0)
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
       lucide-react:
         specifier: ^0.356.0
         version: 0.356.0(react@18.3.1)
@@ -207,7 +207,7 @@ importers:
         version: 4.5.7(@types/react@18.3.26)(react@18.3.1)
     devDependencies:
       '@types/better-sqlite3':
-        specifier: ^7.6.9
+        specifier: ^7.6.13
         version: 7.6.13
       '@types/node':
         specifier: ^20.11.0
@@ -7369,6 +7369,15 @@ packages:
       bindings: 1.5.0
       prebuild-install: 7.1.3
 
+  /better-sqlite3@12.10.0:
+    resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+    requiresBuild: true
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+    dev: false
+
   /better-sqlite3@9.6.0:
     resolution: {integrity: sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==}
     requiresBuild: true
@@ -7376,6 +7385,7 @@ packages:
       bindings: 1.5.0
       prebuild-install: 7.1.3
     dev: false
+    optional: true
 
   /bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
@@ -8319,7 +8329,7 @@ packages:
       tsx: 4.22.4
     dev: true
 
-  /drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@9.6.0):
+  /drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0):
     resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
@@ -8412,7 +8422,7 @@ packages:
         optional: true
     dependencies:
       '@types/better-sqlite3': 7.6.13
-      better-sqlite3: 9.6.0
+      better-sqlite3: 12.10.0
     dev: false
 
   /duck@0.1.12:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   ajv@6: ^6.14.0
   ajv@8: ^8.18.0
   basic-ftp: '>=5.3.1'
+  better-sqlite3: 11.10.0
   brace-expansion@1: ^1.1.13
   brace-expansion@2: ^2.0.3
   esbuild@<0.25.0: '>=0.25.0'
@@ -30,11 +31,11 @@ overrides:
   js-yaml@4: ^4.1.1
   lodash: ^4.18.0
   mdast-util-to-hast@13: ^13.2.1
+  minimatch@10: ^10.2.3
   minimatch@3: ^3.1.4
   minimatch@5: ^5.1.8
   minimatch@7: ^7.4.8
   minimatch@9: ^9.0.7
-  minimatch@10: ^10.2.3
   mongoose@8: ^8.22.1
   picomatch@2: ^2.3.2
   picomatch@4: ^4.0.4
@@ -50,9 +51,9 @@ overrides:
   undici@7: ^7.24.0
   uuid: '>=11.1.1'
   validator: ^13.15.22
+  vite@<6.4.2: ^6.4.2
   ws@8: ^8.20.1
   yaml@2: ^2.8.3
-  vite@<6.4.2: ^6.4.2
 
 importers:
 
@@ -164,8 +165,8 @@ importers:
         specifier: ^12.0.0
         version: 12.9.2(@types/react@18.3.26)(react-dom@18.3.1)(react@18.3.1)
       better-sqlite3:
-        specifier: ^12.4.1
-        version: 12.10.0
+        specifier: 11.10.0
+        version: 11.10.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -174,7 +175,7 @@ importers:
         version: 2.1.1
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)
+        version: 0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)
       lucide-react:
         specifier: ^0.356.0
         version: 0.356.0(react@18.3.1)
@@ -246,7 +247,7 @@ importers:
   packages/analytics:
     dependencies:
       better-sqlite3:
-        specifier: '>=9.0.0'
+        specifier: 11.10.0
         version: 11.10.0
       eventemitter3:
         specifier: ^5.0.1
@@ -302,7 +303,7 @@ importers:
         specifier: ^4.0.0
         version: 4.1.0
       better-sqlite3:
-        specifier: ^11.7.0
+        specifier: 11.10.0
         version: 11.10.0
       ioredis:
         specifier: ^5.4.1
@@ -456,7 +457,7 @@ importers:
         specifier: ^8.11.10
         version: 8.16.0
       better-sqlite3:
-        specifier: ^11.6.0
+        specifier: 11.10.0
         version: 11.10.0
       eslint:
         specifier: ^9.17.0
@@ -530,7 +531,7 @@ importers:
         version: 5.1.6
     optionalDependencies:
       better-sqlite3:
-        specifier: ^11.7.0
+        specifier: 11.10.0
         version: 11.10.0
     devDependencies:
       '@types/deep-diff':
@@ -571,8 +572,8 @@ importers:
         specifier: ^1.7.0
         version: 1.16.2(typescript@5.9.3)
       better-sqlite3:
-        specifier: ^9.2.0
-        version: 9.6.0
+        specifier: 11.10.0
+        version: 11.10.0
       chromadb:
         specifier: ^1.7.0
         version: 1.10.5
@@ -618,8 +619,8 @@ importers:
         specifier: ^0.14.0
         version: 0.14.11
       better-sqlite3:
-        specifier: ^9.2.0
-        version: 9.6.0
+        specifier: 11.10.0
+        version: 11.10.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.0
@@ -827,7 +828,7 @@ importers:
         specifier: ^2.0.0
         version: 2.2.2
       better-sqlite3:
-        specifier: ^11.0.0
+        specifier: 11.10.0
         version: 11.10.0
       ioredis:
         specifier: ^5.3.0
@@ -935,7 +936,7 @@ importers:
         specifier: ^3.721.0
         version: 3.948.0
       better-sqlite3:
-        specifier: ^11.7.0
+        specifier: 11.10.0
         version: 11.10.0
       pg:
         specifier: ^8.13.1
@@ -7369,24 +7370,6 @@ packages:
       bindings: 1.5.0
       prebuild-install: 7.1.3
 
-  /better-sqlite3@12.10.0:
-    resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
-    requiresBuild: true
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
-    dev: false
-
-  /better-sqlite3@9.6.0:
-    resolution: {integrity: sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==}
-    requiresBuild: true
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
-    dev: false
-    optional: true
-
   /bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
     dev: false
@@ -8329,7 +8312,7 @@ packages:
       tsx: 4.22.4
     dev: true
 
-  /drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0):
+  /drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0):
     resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
@@ -8349,7 +8332,7 @@ packages:
       '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
-      better-sqlite3: '>=7'
+      better-sqlite3: 11.10.0
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
       gel: '>=2'
@@ -8422,7 +8405,7 @@ packages:
         optional: true
     dependencies:
       '@types/better-sqlite3': 7.6.13
-      better-sqlite3: 12.10.0
+      better-sqlite3: 11.10.0
     dev: false
 
   /duck@0.1.12:
@@ -12517,6 +12500,7 @@ packages:
   /prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
     dependencies:
       detect-libc: 2.1.2


### PR DESCRIPTION
## v0.8.0

### Security
- **NestJS 10 → 11** (`@nestjs/*` ^11.1.26 in `@lov3kaizen/agentsea-nestjs`) — clears the final audit finding. `pnpm audit` now reports **zero known vulnerabilities** (168 at the start of this effort).
- Peer ranges in crews/costs/guardrails/surf widened to `^10.0.0 || ^11.0.0` so consumers on either Nest major remain compatible.

### Fixes
- `drizzle.config.ts` migrated to drizzle-kit 0.31 syntax (`dialect: 'sqlite'`, better-sqlite3 retained — no Turso needed for a local DB).
- Migration snapshots upgraded via `drizzle-kit up`; generated `0001` migration for the `agents.model` column default → `claude-opus-4-8`.

### Verification
- 48 package builds green; all 16 test suites pass (~4,900 tests).
- admin-ui builds cleanly on Next 15 (13 routes, types + lint pass, React 18).
- CI: Windows native builds fixed (better-sqlite3 pinned to 11.10.0 for prebuild coverage; admin-ui excluded from cross-OS matrix; EOL Node 18 dropped). All checks green on Node 20/22 × ubuntu/windows/macos.

### Versions
- 0.7.0 → 0.8.0 across the 11-package release track.
