### PR TITLE
chore: align remaining packages to 1.0.0

### DIFF
--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-admin-ui",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "Web-based admin UI for AgentSea SDK - Visual workflow builder and agent management",
   "private": true,
   "scripts": {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-analytics",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "Conversation analytics for AI agents - intent classification, flow analysis, sentiment tracking, and insights",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-cli",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "CLI tool for AgentSea ADK - Build and orchestrate AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-core",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "AgentSea - Unite and orchestrate AI agents. A production-ready ADK for building agentic AI applications with multi-provider support.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/costs/package.json
+++ b/packages/costs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-costs",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "AI cost management platform with real-time tracking, budget enforcement, and optimization",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-nestjs",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "NestJS integration for AgentSea - Unite and orchestrate AI agents in your NestJS applications",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-react",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "React components for rendering AgentSea agent responses with formatting support",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/structured/package.json
+++ b/packages/structured/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-structured",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "TypeScript-native structured output framework - Zod schema enforcement for LLM responses",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/surf/package.json
+++ b/packages/surf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-surf",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "Surf - Computer-use agent for AgentSea. Control desktop environments through screen capture, mouse, and keyboard actions using Claude's vision capabilities.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-types",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "Type definitions for AgentSea ADK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Bump analytics, cli, core, costs, nestjs, react, structured, surf, types (and private admin-ui) from 0.8.0 to 1.0.0 to reconcile the monorepo version split with the packages already at 1.0.0.