### PR TITLE
docs: reconcile maturity status (Crews WIP→Beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,13 +755,15 @@ README); **WIP** = under active development, APIs and behavior may change.
   audit logging, and continuous testing now ship functional MVP implementations
   with tests (some advanced options — persistent audit storage, cron schedules,
   alert delivery — are still pending).
+- [~] **Crews** — multi-agent orchestration with role-based coordination and
+  delegation strategies (round-robin, best-match, auction, hierarchical,
+  consensus). Orchestration, workflows, strategies, and **real LLM execution by
+  default** (via the core-backed `CoreExecutor`; deterministic mock path is
+  opt-in with `mock: true`) are implemented. Live-provider end-to-end coverage
+  is still being expanded.
 
 ### 🚧 Work in Progress
 
-- [ ] **Crews** — multi-agent orchestration with role-based coordination and
-      delegation strategies (round-robin, best-match, auction, hierarchical,
-      consensus). Orchestration, workflows, and most strategies are implemented,
-      but agents do not yet execute against a real LLM out of the box.
 - [ ] Admin UI dashboard improvements
 - [ ] Additional MCP tools/servers
 - [ ] Enhanced computer-use agent capabilities


### PR DESCRIPTION
Base of the maturity-gap PR stack. Stacked on #33.

#33 wired real LLM execution into crew agents by default (`CoreExecutor`), making the README's WIP claim that *"agents do not yet execute against a real LLM out of the box"* inaccurate.

This PR moves **Crews** from 🚧 Work in Progress → 🧪 Beta with an accurate note: real execution is the default, the deterministic mock path is opt-in via `mock: true`, and live-provider e2e coverage is still being expanded.

## Stack
1. **docs: reconcile maturity (this PR)**
2. feat(crews): live-provider e2e + graduate
3. feat(evaluate): alert channels + HuggingFace import/export
4. feat(redteam): persistent audit + cron scheduler + alert delivery
5. feat(embeddings): pgvector/Weaviate/Milvus + local ONNX
6. feat(surf): Playwright backend + integration tests