### PR TITLE
feat(redteam): persistent audit storage + cron schedules + real alert delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,12 @@ README); **WIP** = under active development, APIs and behavior may change.
       nodemailer), webhook/Slack, and PagerDuty (Events API v2) alert channels;
       HuggingFace dataset import (datasets-server REST) and Hub export
       (`@huggingface/hub`).
+- [x] **Red Team** — adversarial attack generation, vulnerability scanning, and
+      jailbreak detection; safety benchmarks, compliance checking. Continuous
+      testing with cron-driven schedules (`cron-parser`), real alert delivery
+      (webhook/Slack/Teams/Discord/PagerDuty/email), and tamper-evident,
+      hash-chained audit logging with pluggable persistent storage
+      (`FileAuditStore`).
 
 ### 🧪 Beta
 
@@ -757,11 +763,6 @@ README); **WIP** = under active development, APIs and behavior may change.
 - [~] **Surf** — vision-driven computer use and browser automation. Puppeteer +
   Docker/Linux/macOS/Windows backends exist but lack integration test coverage;
   there is no Playwright backend yet and some native input paths are fragile.
-- [~] **Red Team** — adversarial attack generation, vulnerability scanning, and
-  jailbreak detection are implemented. Safety benchmarks, compliance checking,
-  audit logging, and continuous testing now ship functional MVP implementations
-  with tests (some advanced options — persistent audit storage, cron schedules,
-  alert delivery — are still pending).
 
 ### 🚧 Work in Progress
 

--- a/packages/redteam/package.json
+++ b/packages/redteam/package.json
@@ -85,8 +85,12 @@
     "directory": "packages/redteam"
   },
   "dependencies": {
+    "cron-parser": "^5.0.4",
     "eventemitter3": "^5.0.1",
     "nanoid": "^5.0.9"
+  },
+  "optionalDependencies": {
+    "nodemailer": "^6.9.0"
   },
   "devDependencies": {
     "tsup": "^8.5.0",

--- a/packages/redteam/src/__tests__/audit-cron-alerts.test.ts
+++ b/packages/redteam/src/__tests__/audit-cron-alerts.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for the continuous-testing maturity work:
+ *  - cron-driven schedules (nextRunAt / nextCronAt)
+ *  - real alert delivery (webhook / slack / pagerduty / email)
+ *  - persistent, hash-chained audit storage (FileAuditStore)
+ *
+ * HTTP (fetch), SMTP (nodemailer) are mocked; the file store uses a real temp
+ * file so persistence and chain-replay are exercised end to end.
+ */
+
+import { describe, it, expect, vi, afterEach, type Mock } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rmSync, existsSync } from 'node:fs';
+import { nanoid } from 'nanoid';
+
+vi.mock('../utils/optional-import.js', () => ({
+  importOptional: vi.fn(),
+}));
+
+import { importOptional } from '../utils/optional-import.js';
+import { nextRunAt, nextCronAt, AlertManager } from '../continuous/index.js';
+import { AuditLogger, FileAuditStore } from '../audit/index.js';
+import type { AlertChannel, AlertRule } from '../types/continuous.types.js';
+
+const importOptionalMock = importOptional as unknown as Mock;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('cron schedules', () => {
+  it('computes the next fire time for a custom cron expression', () => {
+    // 2020-01-01T00:30:00Z; "0 * * * *" fires at the top of every hour.
+    const from = Date.UTC(2020, 0, 1, 0, 30, 0);
+    const next = nextRunAt(
+      { frequency: 'custom', cronExpression: '0 * * * *', timezone: 'UTC' },
+      from,
+    );
+    expect(next).toBe(Date.UTC(2020, 0, 1, 1, 0, 0));
+  });
+
+  it('returns null for custom frequency without an expression', () => {
+    expect(nextRunAt({ frequency: 'custom' }, 0)).toBeNull();
+  });
+
+  it('returns null for an invalid cron expression', () => {
+    expect(nextCronAt('not a cron', 0)).toBeNull();
+  });
+});
+
+describe('AlertManager delivery', () => {
+  const rule: AlertRule = {
+    id: 'rule-1',
+    name: 'High fail rate',
+    enabled: true,
+    condition: {
+      type: 'threshold',
+      metric: 'failRate',
+      operator: 'greater',
+      value: 0.3,
+    },
+    severity: 'critical',
+    channelIds: ['ch-webhook'],
+  };
+
+  function channel(over: Partial<AlertChannel>): AlertChannel {
+    return {
+      id: 'ch-webhook',
+      type: 'webhook',
+      name: 'hook',
+      enabled: true,
+      config: { webhookUrl: 'https://example.com/hook' },
+      severities: ['critical', 'warning', 'info'],
+      ...over,
+    };
+  }
+
+  it('delivers to a webhook and records success', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const mgr = new AlertManager({ rules: [rule], channels: [channel({})] });
+    const alerts = await mgr.evaluateAndDeliver({ failRate: 0.9 });
+
+    expect(alerts).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/hook',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(alerts[0].notificationHistory).toEqual([
+      expect.objectContaining({ channelId: 'ch-webhook', status: 'sent' }),
+    ]);
+  });
+
+  it('records a failure when the webhook URL is missing', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    const mgr = new AlertManager({
+      rules: [rule],
+      channels: [channel({ config: {} })],
+    });
+
+    const [alert] = await mgr.evaluateAndDeliver({ failRate: 0.9 });
+    expect(alert.notificationHistory[0].status).toBe('failed');
+    expect(alert.notificationHistory[0].error).toMatch(/webhookUrl/);
+  });
+
+  it('enqueues a PagerDuty Events API v2 trigger', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 202 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const mgr = new AlertManager({
+      rules: [{ ...rule, channelIds: ['pd'] }],
+      channels: [
+        channel({
+          id: 'pd',
+          type: 'pagerduty',
+          config: { apiKey: 'routing-key' },
+        }),
+      ],
+    });
+
+    await mgr.evaluateAndDeliver({ failRate: 0.9 });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://events.pagerduty.com/v2/enqueue');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body.routing_key).toBe('routing-key');
+    expect(body.payload.severity).toBe('critical');
+  });
+
+  it('skips channels whose severity routing excludes the alert', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const mgr = new AlertManager({
+      rules: [rule],
+      channels: [channel({ severities: ['info'] })], // critical not routed here
+    });
+
+    const [alert] = await mgr.evaluateAndDeliver({ failRate: 0.9 });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(alert.notificationHistory).toHaveLength(0);
+  });
+
+  it('delivers email via the optional nodemailer dependency', async () => {
+    const sendMail = vi.fn().mockResolvedValue({ messageId: 'x' });
+    const createTransport = vi.fn().mockReturnValue({ sendMail });
+    importOptionalMock.mockResolvedValue({ createTransport });
+
+    const mgr = new AlertManager({
+      rules: [{ ...rule, channelIds: ['mail'] }],
+      channels: [
+        channel({
+          id: 'mail',
+          type: 'email',
+          config: {
+            emails: ['soc@example.com'],
+            settings: { smtp: { host: 'smtp.example.com', port: 587 } },
+          },
+        }),
+      ],
+    });
+
+    const [alert] = await mgr.evaluateAndDeliver({ failRate: 0.9 });
+
+    expect(createTransport).toHaveBeenCalledWith(
+      expect.objectContaining({ host: 'smtp.example.com' }),
+    );
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'soc@example.com' }),
+    );
+    expect(alert.notificationHistory[0].status).toBe('sent');
+  });
+});
+
+describe('FileAuditStore persistence', () => {
+  function tmpPath(): string {
+    return join(tmpdir(), `agentsea-audit-${nanoid()}.jsonl`);
+  }
+
+  function entryInput(action: string) {
+    return {
+      eventType: 'test_started' as const,
+      action,
+      actor: { id: 'tester', type: 'system' as const },
+      resource: { id: 'target-1', type: 'test' as const },
+      outcome: 'success' as const,
+    };
+  }
+
+  it('persists entries and replays a valid chain after restart', async () => {
+    const path = tmpPath();
+    try {
+      const store1 = new FileAuditStore(path);
+      const logger1 = new AuditLogger({ store: store1 });
+      logger1.log(entryInput('probe-1'));
+      logger1.log(entryInput('probe-2'));
+
+      expect(existsSync(path)).toBe(true);
+
+      // Simulate a restart: a fresh logger hydrates from the same store.
+      const logger2 = new AuditLogger({ store: new FileAuditStore(path) });
+      const loaded = await logger2.loadFromStore();
+
+      expect(loaded).toBe(2);
+      expect(logger2.getEntries().map((e) => e.action)).toEqual([
+        'probe-1',
+        'probe-2',
+      ]);
+
+      // The replayed chain is intact, and new entries link onto it.
+      expect(logger2.verifyIntegrity().status).toBe('valid');
+      logger2.log(entryInput('probe-3'));
+      expect(logger2.verifyIntegrity().status).toBe('valid');
+
+      // And the third entry was persisted too.
+      const reloaded = new FileAuditStore(path).loadAll();
+      expect(reloaded).toHaveLength(3);
+    } finally {
+      rmSync(path, { force: true });
+    }
+  });
+
+  it('clear() empties the persisted store', () => {
+    const path = tmpPath();
+    try {
+      const store = new FileAuditStore(path);
+      const logger = new AuditLogger({ store });
+      logger.log(entryInput('probe-1'));
+      logger.clear();
+      expect(store.loadAll()).toHaveLength(0);
+    } finally {
+      rmSync(path, { force: true });
+    }
+  });
+});

--- a/packages/redteam/src/audit/index.ts
+++ b/packages/redteam/src/audit/index.ts
@@ -19,6 +19,14 @@ import type {
   EvidencePackageSummary,
 } from '../types/audit.types.js';
 import type { Evidence } from '../types/compliance.types.js';
+import {
+  type AuditStore,
+  FileAuditStore,
+  createFileAuditStore,
+} from './storage.js';
+
+export { FileAuditStore, createFileAuditStore };
+export type { AuditStore };
 
 // Re-export types
 export type {
@@ -79,9 +87,23 @@ export class AuditLogger {
   private readonly enabled: boolean;
   private readonly trailId = nanoid();
   private readonly startTime = Date.now();
+  private readonly store?: AuditStore;
 
-  constructor(config: { enabled?: boolean } = {}) {
+  constructor(config: { enabled?: boolean; store?: AuditStore } = {}) {
     this.enabled = config.enabled ?? true;
+    this.store = config.store;
+  }
+
+  /**
+   * Hydrate the in-memory chain from the configured persistent store. Call this
+   * once after construction (e.g. on process start) to resume an existing,
+   * tamper-evident trail. Returns the number of entries loaded.
+   */
+  async loadFromStore(): Promise<number> {
+    if (!this.store) return 0;
+    const loaded = await this.store.loadAll();
+    this.entries = loaded;
+    return loaded.length;
   }
 
   /** Append a new entry, linking it to the previous one. Returns the stored entry. */
@@ -102,6 +124,8 @@ export class AuditLogger {
 
     if (this.enabled) {
       this.entries.push(entry);
+      // Persist after linking so the durable record matches the in-memory chain.
+      void this.store?.append(entry);
     }
     return entry;
   }
@@ -251,6 +275,7 @@ export class AuditLogger {
 
   clear(): void {
     this.entries = [];
+    void this.store?.clear();
   }
 }
 
@@ -332,7 +357,10 @@ export class EvidenceCollector {
   }
 }
 
-export function createAuditLogger(config?: { enabled?: boolean }): AuditLogger {
+export function createAuditLogger(config?: {
+  enabled?: boolean;
+  store?: AuditStore;
+}): AuditLogger {
   return new AuditLogger(config);
 }
 

--- a/packages/redteam/src/audit/storage.ts
+++ b/packages/redteam/src/audit/storage.ts
@@ -1,0 +1,76 @@
+/**
+ * Persistent audit storage.
+ *
+ * The {@link AuditLogger} keeps a hash-chained log in memory; an {@link AuditStore}
+ * lets that chain survive process restarts. The append-only file store maps
+ * naturally onto the append-only chain: each entry is one JSON line, so writes
+ * are O(1) appends and the whole chain can be replayed (and re-verified) on load.
+ */
+
+import {
+  appendFileSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+import type { AuditEntry } from '../types/audit.types.js';
+
+/**
+ * Pluggable persistence backend for the audit log. Implementations must
+ * preserve insertion order so the hash chain can be replayed verbatim.
+ */
+export interface AuditStore {
+  /** Durably append a single entry. */
+  append(entry: AuditEntry): void | Promise<void>;
+  /** Load every persisted entry in insertion order. */
+  loadAll(): AuditEntry[] | Promise<AuditEntry[]>;
+  /** Remove all persisted entries. */
+  clear(): void | Promise<void>;
+}
+
+/**
+ * Append-only, file-backed audit store using JSON Lines (one entry per line).
+ *
+ * Writes use synchronous appends so an entry is durable the moment
+ * {@link AuditLogger.log} returns — important for tamper-evident logging, where
+ * losing the most recent entries on a crash would break the chain.
+ */
+export class FileAuditStore implements AuditStore {
+  constructor(private readonly filePath: string) {}
+
+  append(entry: AuditEntry): void {
+    this.ensureDir();
+    appendFileSync(this.filePath, JSON.stringify(entry) + '\n', 'utf8');
+  }
+
+  loadAll(): AuditEntry[] {
+    if (!existsSync(this.filePath)) return [];
+    const raw = readFileSync(this.filePath, 'utf8');
+    const entries: AuditEntry[] = [];
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      entries.push(JSON.parse(trimmed) as AuditEntry);
+    }
+    return entries;
+  }
+
+  clear(): void {
+    this.ensureDir();
+    writeFileSync(this.filePath, '', 'utf8');
+  }
+
+  private ensureDir(): void {
+    const dir = dirname(this.filePath);
+    if (dir && !existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  }
+}
+
+/** Create a file-backed audit store at the given path. */
+export function createFileAuditStore(filePath: string): FileAuditStore {
+  return new FileAuditStore(filePath);
+}

--- a/packages/redteam/src/continuous/index.ts
+++ b/packages/redteam/src/continuous/index.ts
@@ -9,16 +9,19 @@
 
 import { EventEmitter } from 'eventemitter3';
 import { nanoid } from 'nanoid';
+import { CronExpressionParser } from 'cron-parser';
 import type {
   ScheduleConfig,
   AlertRule,
   AlertChannel,
   Alert,
+  NotificationRecord,
   TestRun,
   RunStatus,
   RunSummary,
   TriggerConfig,
 } from '../types/continuous.types.js';
+import { importOptional } from '../utils/optional-import.js';
 
 // Re-export types
 export type {
@@ -73,9 +76,35 @@ export function nextRunAt(
       return from + WEEK;
     case 'monthly':
       return from + 30 * DAY;
+    case 'custom':
+      // Custom schedules are driven by a cron expression when provided.
+      return schedule.cronExpression
+        ? nextCronAt(schedule.cronExpression, from, schedule.timezone)
+        : null;
     default:
-      // on_deploy / on_change / custom are event/cron driven, not time-scheduled.
+      // on_deploy / on_change are event-driven, not time-scheduled.
       return null;
+  }
+}
+
+/**
+ * Compute the next fire time (epoch ms) strictly after `from` for a standard
+ * cron expression. Returns null if the expression is invalid so a bad schedule
+ * degrades to "never auto-runs" rather than throwing.
+ */
+export function nextCronAt(
+  cronExpression: string,
+  from: number,
+  timezone?: string,
+): number | null {
+  try {
+    const interval = CronExpressionParser.parse(cronExpression, {
+      currentDate: new Date(from),
+      tz: timezone,
+    });
+    return interval.next().getTime();
+  } catch {
+    return null;
   }
 }
 
@@ -160,6 +189,18 @@ interface AlertManagerEvents {
   alert: (alert: Alert) => void;
 }
 
+/** Minimal structural contract for `nodemailer` (optional email dependency). */
+interface NodemailerLike {
+  createTransport(options: unknown): {
+    sendMail(mail: {
+      from: string;
+      to: string;
+      subject: string;
+      text: string;
+    }): Promise<unknown>;
+  };
+}
+
 /**
  * Evaluates threshold/change alert rules against a metrics snapshot and emits
  * `Alert`s. Records a notification per configured channel (delivery itself is
@@ -187,7 +228,9 @@ export class AlertManager extends EventEmitter<AlertManagerEvents> {
 
   /**
    * Evaluate all enabled rules against a metrics snapshot. Returns (and emits)
-   * an Alert for every rule whose condition is met.
+   * an Alert for every rule whose condition is met. Notifications are not
+   * delivered here — call {@link AlertManager.deliver} (or use
+   * {@link AlertManager.evaluateAndDeliver}) to actually contact channels.
    */
   evaluate(metrics: Record<string, number>, runId?: string): Alert[] {
     const alerts: Alert[] = [];
@@ -209,12 +252,7 @@ export class AlertManager extends EventEmitter<AlertManagerEvents> {
         details: { metric: rule.condition.metric, value },
         triggeredAt: Date.now(),
         runId,
-        notificationHistory: this.channels.map((ch) => ({
-          channelId: ch.id,
-          channelType: ch.type,
-          sentAt: Date.now(),
-          status: 'sent' as const,
-        })),
+        notificationHistory: [],
       };
 
       alerts.push(alert);
@@ -222,6 +260,201 @@ export class AlertManager extends EventEmitter<AlertManagerEvents> {
     }
 
     return alerts;
+  }
+
+  /** Evaluate rules and deliver notifications for every triggered alert. */
+  async evaluateAndDeliver(
+    metrics: Record<string, number>,
+    runId?: string,
+  ): Promise<Alert[]> {
+    const alerts = this.evaluate(metrics, runId);
+    for (const alert of alerts) {
+      await this.deliver(alert);
+    }
+    return alerts;
+  }
+
+  /**
+   * Deliver an alert to the channels configured on its triggering rule (falling
+   * back to all channels when the rule lists none). Each channel attempt is
+   * recorded on the alert's `notificationHistory`; failures are captured rather
+   * than thrown so one bad channel never blocks the others.
+   */
+  async deliver(alert: Alert): Promise<NotificationRecord[]> {
+    const rule = this.rules.find((r) => r.id === alert.ruleId);
+    const targetIds = rule?.channelIds?.length ? rule.channelIds : undefined;
+
+    const targets = this.channels.filter((ch) => {
+      if (!ch.enabled) return false;
+      if (targetIds && !targetIds.includes(ch.id)) return false;
+      // Honor per-channel severity routing when specified.
+      if (ch.severities?.length && !ch.severities.includes(alert.severity)) {
+        return false;
+      }
+      return true;
+    });
+
+    const records: NotificationRecord[] = [];
+    for (const channel of targets) {
+      const record: NotificationRecord = {
+        channelId: channel.id,
+        channelType: channel.type,
+        sentAt: Date.now(),
+        status: 'sent',
+      };
+      try {
+        await this.deliverToChannel(channel, alert);
+      } catch (e) {
+        record.status = 'failed';
+        record.error = e instanceof Error ? e.message : String(e);
+      }
+      records.push(record);
+    }
+
+    alert.notificationHistory = records;
+    return records;
+  }
+
+  /** Deliver a single alert to a single channel based on its type. */
+  private async deliverToChannel(
+    channel: AlertChannel,
+    alert: Alert,
+  ): Promise<void> {
+    const cfg = channel.config;
+    const text = `[${alert.severity.toUpperCase()}] ${alert.title} — ${alert.message}`;
+
+    switch (channel.type) {
+      case 'webhook':
+      case 'custom': {
+        await this.postJson(
+          cfg.webhookUrl,
+          {
+            id: alert.id,
+            ruleId: alert.ruleId,
+            severity: alert.severity,
+            title: alert.title,
+            message: alert.message,
+            details: alert.details,
+            triggeredAt: alert.triggeredAt,
+          },
+          cfg.headers,
+        );
+        break;
+      }
+      case 'slack': {
+        await this.postJson(cfg.webhookUrl, { text }, cfg.headers);
+        break;
+      }
+      case 'discord': {
+        await this.postJson(cfg.webhookUrl, { content: text }, cfg.headers);
+        break;
+      }
+      case 'teams': {
+        await this.postJson(cfg.webhookUrl, { text }, cfg.headers);
+        break;
+      }
+      case 'pagerduty': {
+        const routingKey = cfg.apiKey;
+        if (!routingKey) {
+          throw new Error(
+            'PagerDuty channel requires config.apiKey (routing key)',
+          );
+        }
+        const severity =
+          alert.severity === 'critical'
+            ? 'critical'
+            : alert.severity === 'warning'
+              ? 'warning'
+              : 'info';
+        const res = await fetch('https://events.pagerduty.com/v2/enqueue', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            routing_key: routingKey,
+            event_action: 'trigger',
+            dedup_key: `agentsea-redteam:${alert.ruleId}`,
+            payload: {
+              summary: alert.message,
+              source: 'agentsea-redteam',
+              severity,
+              custom_details: alert.details,
+            },
+          }),
+        });
+        if (!res.ok) {
+          throw new Error(
+            `PagerDuty enqueue failed: ${res.status} ${res.statusText}`,
+          );
+        }
+        break;
+      }
+      case 'email': {
+        await this.deliverEmail(channel, alert, text);
+        break;
+      }
+    }
+  }
+
+  /** POST a JSON body to a webhook URL, throwing on a missing URL or non-2xx. */
+  private async postJson(
+    url: string | undefined,
+    body: unknown,
+    headers?: Record<string, string>,
+  ): Promise<void> {
+    if (!url) {
+      throw new Error('Channel requires config.webhookUrl');
+    }
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Webhook delivery failed: ${res.status} ${res.statusText}`,
+      );
+    }
+  }
+
+  /** Deliver an email alert via the optional `nodemailer` dependency. */
+  private async deliverEmail(
+    channel: AlertChannel,
+    alert: Alert,
+    text: string,
+  ): Promise<void> {
+    const recipients = channel.config.emails;
+    if (!recipients?.length) {
+      throw new Error('Email channel requires config.emails');
+    }
+    const smtp = channel.config.settings?.smtp as
+      | { host: string; port?: number; secure?: boolean; auth?: unknown }
+      | undefined;
+    if (!smtp?.host) {
+      throw new Error('Email channel requires config.settings.smtp.host');
+    }
+
+    let mod: unknown;
+    try {
+      mod = await importOptional('nodemailer');
+    } catch {
+      throw new Error(
+        'Email alerts require the "nodemailer" package; install it or use a ' +
+          'different channel type.',
+      );
+    }
+    const mailer = ((mod as { default?: NodemailerLike }).default ??
+      mod) as NodemailerLike;
+
+    const from =
+      (channel.config.settings?.from as string | undefined) ??
+      'alerts@agentsea.local';
+    const transport = mailer.createTransport(smtp);
+    await transport.sendMail({
+      from,
+      to: recipients.join(', '),
+      subject: `[${alert.severity.toUpperCase()}] ${alert.title}`,
+      text,
+    });
   }
 
   private conditionMet(rule: AlertRule, value: number): boolean {
@@ -286,7 +519,11 @@ export class ContinuousTesting {
       summary = result.summary;
       status = 'completed';
       if (result.metrics) {
-        triggeredAlerts = this.alerts.evaluate(result.metrics, id);
+        // Evaluate alert rules and deliver notifications to configured channels.
+        triggeredAlerts = await this.alerts.evaluateAndDeliver(
+          result.metrics,
+          id,
+        );
       }
     } catch (e) {
       status = 'failed';

--- a/packages/redteam/src/index.ts
+++ b/packages/redteam/src/index.ts
@@ -140,6 +140,9 @@ export {
   EvidenceCollector,
   createAuditLogger,
   createEvidenceCollector,
+  FileAuditStore,
+  createFileAuditStore,
+  type AuditStore,
   type AuditEntryInput,
 } from './audit/index.js';
 
@@ -152,6 +155,7 @@ export {
   createScheduler,
   createAlertManager,
   nextRunAt,
+  nextCronAt,
   type TestRunner,
 } from './continuous/index.js';
 

--- a/packages/redteam/src/utils/optional-import.ts
+++ b/packages/redteam/src/utils/optional-import.ts
@@ -1,0 +1,9 @@
+/**
+ * Import an optional dependency at runtime by name without TypeScript resolving
+ * the literal specifier at build time, so the package compiles and runs without
+ * the dependency installed. Callers cast the result to a minimal local contract
+ * and handle rejection when the module is absent.
+ */
+export function importOptional(name: string): Promise<unknown> {
+  return import(/* @vite-ignore */ /* webpackIgnore: true */ name);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1042,12 +1042,19 @@ importers:
       '@lov3kaizen/agentsea-core':
         specifier: '>=0.6.0'
         version: 1.0.1
+      cron-parser:
+        specifier: ^5.0.4
+        version: 5.6.1
       eventemitter3:
         specifier: ^5.0.1
         version: 5.0.1
       nanoid:
         specifier: ^5.0.9
         version: 5.1.6
+    optionalDependencies:
+      nodemailer:
+        specifier: ^6.9.0
+        version: 6.10.1
     devDependencies:
       tsup:
         specifier: ^8.5.0
@@ -7014,7 +7021,7 @@ packages:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 6.4.3(@types/node@22.19.3)
+      vite: 6.4.3(@types/node@20.19.24)
     dev: true
 
   /@vitest/pretty-format@3.2.6:
@@ -8135,6 +8142,13 @@ packages:
   /corser@2.0.1:
     resolution: {integrity: sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==}
     engines: {node: '>= 0.4.0'}
+    dev: false
+
+  /cron-parser@5.6.1:
+    resolution: {integrity: sha512-QBm4o1PwZiuY7KFbVvW7FLC8bozy7YWzv+Fz6KRS7sQghzcbDZCGxr/Bc5b6TQreAoSwuWVP491dIcK0THCX6A==}
+    engines: {node: '>=18'}
+    dependencies:
+      luxon: 3.7.2
     dev: false
 
   /croner@9.1.0:
@@ -11278,6 +11292,11 @@ packages:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.3.1
+    dev: false
+
+  /luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
     dev: false
 
   /lz-string@1.5.0:
@@ -15307,7 +15326,7 @@ packages:
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 6.4.3(@types/node@22.19.3)


### PR DESCRIPTION
Stack PR 4/6. Stacked on #36.

Closes the **Red Team** Beta gaps (persistent audit storage, cron schedules, alert delivery were pending).

## Persistent audit storage
- New `AuditStore` interface + `FileAuditStore` (append-only JSONL, synchronous durable writes)
- `AuditLogger` accepts a `store`, persists every entry, and `loadFromStore()` replays a tamper-evident, hash-chained trail across restarts (new entries link onto the replayed chain)

## Cron schedules
- `nextRunAt()` resolves `frequency: 'custom'` via **cron-parser** (new timezone-aware `nextCronAt` helper); invalid expressions degrade to `null` instead of throwing

## Real alert delivery
- `AlertManager.deliver()` / `evaluateAndDeliver()` actually contact channels: webhook/Slack/Teams/Discord (`fetch`), **PagerDuty** (Events API v2), and **email** (optional `nodemailer`)
- Per-channel severity routing honored; per-channel failures captured in `notificationHistory` rather than thrown
- `ContinuousTesting.runOnce` now delivers via `evaluateAndDeliver`

## Tests
- redteam: 45 passed (10 new: cron, delivery per channel, file persistence + chain replay)
- type-check / lint / build clean
- README: Red Team graduated 🧪 Beta → ✅ Stable