### PR TITLE
feat(embeddings): pgvector/Weaviate/Milvus stores + local ONNX

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,12 +754,13 @@ README); **WIP** = under active development, APIs and behavior may change.
       (webhook/Slack/Teams/Discord/PagerDuty/email), and tamper-evident,
       hash-chained audit logging with pluggable persistent storage
       (`FileAuditStore`).
+- [x] **Embeddings** — multi-provider support (OpenAI, Cohere, Voyage, HuggingFace),
+      chunking, caching, and Pinecone/Chroma/Qdrant/**pgvector/Weaviate/Milvus**
+      stores, plus local **ONNX** models via Transformers.js
+      (`@xenova/transformers`).
 
 ### 🧪 Beta
 
-- [~] **Embeddings** — multi-provider support (OpenAI, Cohere, Voyage, HuggingFace),
-  chunking, caching, and Pinecone/Chroma/Qdrant stores. Weaviate/Milvus/pgvector
-  and local ONNX are advertised in types but not yet implemented.
 - [~] **Surf** — vision-driven computer use and browser automation. Puppeteer +
   Docker/Linux/macOS/Windows backends exist but lack integration test coverage;
   there is no Playwright backend yet and some native input paths are fragile.

--- a/packages/embeddings/package.json
+++ b/packages/embeddings/package.json
@@ -37,7 +37,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/chunking/index.ts src/caching/index.ts src/stores/index.ts src/providers/index.ts --format cjs,esm --dts --clean --external ioredis --external better-sqlite3 --external chromadb --external @pinecone-database/pinecone --external @qdrant/js-client-rest --external weaviate-ts-client --external cohere-ai --external ollama",
+    "build": "tsup src/index.ts src/chunking/index.ts src/caching/index.ts src/stores/index.ts src/providers/index.ts --format cjs,esm --dts --clean --external ioredis --external better-sqlite3 --external chromadb --external @pinecone-database/pinecone --external @qdrant/js-client-rest --external weaviate-ts-client --external cohere-ai --external ollama --external pg --external @zilliz/milvus2-sdk-node --external @xenova/transformers",
     "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -94,7 +94,10 @@
     "@pinecone-database/pinecone": "^2.0.0",
     "weaviate-ts-client": "^2.0.0",
     "chromadb": "^1.7.0",
-    "@qdrant/js-client-rest": "^1.7.0"
+    "@qdrant/js-client-rest": "^1.7.0",
+    "pg": "^8.11.0",
+    "@zilliz/milvus2-sdk-node": "^2.4.0",
+    "@xenova/transformers": "^2.17.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/embeddings/src/__tests__/create-store.test.ts
+++ b/packages/embeddings/src/__tests__/create-store.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { createStore, MemoryStore } from '../stores/index.js';
+import {
+  createStore,
+  MemoryStore,
+  PgVectorStore,
+  WeaviateStore,
+  MilvusStore,
+} from '../stores/index.js';
 
 describe('createStore factory', () => {
   it('creates a MemoryStore for type "memory"', () => {
@@ -7,14 +13,31 @@ describe('createStore factory', () => {
     expect(store).toBeInstanceOf(MemoryStore);
   });
 
-  it.each(['weaviate', 'milvus', 'pgvector'] as const)(
-    'throws a clear "not implemented" error for %s instead of silently falling back',
-    (type) => {
-      expect(() => createStore(type, { dimensions: 8 })).toThrow(
-        /not implemented/i,
-      );
-    },
-  );
+  it('creates a PgVectorStore for type "pgvector"', () => {
+    const store = createStore('pgvector', {
+      dimensions: 8,
+      tableName: 'embeddings',
+    } as never);
+    expect(store).toBeInstanceOf(PgVectorStore);
+  });
+
+  it('creates a WeaviateStore for type "weaviate"', () => {
+    const store = createStore('weaviate', {
+      dimensions: 8,
+      url: 'http://localhost:8080',
+      className: 'Doc',
+    } as never);
+    expect(store).toBeInstanceOf(WeaviateStore);
+  });
+
+  it('creates a MilvusStore for type "milvus"', () => {
+    const store = createStore('milvus', {
+      dimensions: 8,
+      url: 'http://localhost:19530',
+      collectionName: 'docs',
+    } as never);
+    expect(store).toBeInstanceOf(MilvusStore);
+  });
 
   it('throws for an unknown store type', () => {
     expect(() =>

--- a/packages/embeddings/src/__tests__/local-provider.test.ts
+++ b/packages/embeddings/src/__tests__/local-provider.test.ts
@@ -1,21 +1,54 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, type Mock } from 'vitest';
+
+vi.mock('../core/optional-import.js', () => ({
+  importOptional: vi.fn(),
+}));
+
 import { LocalProvider } from '../providers/LocalProvider.js';
+import { importOptional } from '../core/optional-import.js';
+
+const importOptionalMock = importOptional as unknown as Mock;
 
 describe('LocalProvider', () => {
-  it('requires an embedFn', () => {
+  it('requires an embedFn or modelPath', () => {
     expect(() => new LocalProvider({ dimensions: 8 } as never)).toThrow(
-      /embedFn/i,
+      /embedFn|modelPath/i,
     );
   });
 
-  it('rejects modelPath (ONNX loading not implemented) with a clear error', () => {
-    expect(
-      () =>
-        new LocalProvider({
-          dimensions: 8,
-          modelPath: '/models/m.onnx',
-        } as never),
-    ).toThrow(/not implemented/i);
+  it('loads an ONNX model from modelPath via Transformers.js', async () => {
+    // Fake feature-extraction pipeline: returns a 2-D tensor-like for inputs.
+    const extractor = vi.fn().mockResolvedValue({
+      tolist: () => [[0.1, 0.2, 0.3]],
+    });
+    const pipeline = vi.fn().mockResolvedValue(extractor);
+    importOptionalMock.mockResolvedValue({ pipeline });
+
+    const provider = new LocalProvider({
+      dimensions: 3,
+      normalize: false,
+      modelPath: 'Xenova/all-MiniLM-L6-v2',
+    } as never);
+
+    const result = await provider.embed('hello');
+
+    expect(pipeline).toHaveBeenCalledWith(
+      'feature-extraction',
+      'Xenova/all-MiniLM-L6-v2',
+    );
+    expect(result.vector).toEqual([0.1, 0.2, 0.3]);
+  });
+
+  it('surfaces a clear error when @xenova/transformers is missing', async () => {
+    importOptionalMock.mockRejectedValue(new Error('Cannot find module'));
+    const provider = new LocalProvider({
+      dimensions: 3,
+      modelPath: '/models/m.onnx',
+    } as never);
+
+    await expect(provider.embed('hello')).rejects.toThrow(
+      /@xenova\/transformers/,
+    );
   });
 
   it('embeds via a custom embedFn', async () => {

--- a/packages/embeddings/src/__tests__/vector-stores.test.ts
+++ b/packages/embeddings/src/__tests__/vector-stores.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for the pgvector / Weaviate / Milvus store adapters.
+ *
+ * The pgvector store is driven through an injected mock `pg` Pool; the Weaviate
+ * and Milvus stores through injected high-level mock backends. This exercises
+ * the stores' translation logic (records -> driver calls, driver rows ->
+ * matches) without any live database. End-to-end coverage against real services
+ * lives behind guarded integration tests.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PgVectorStore } from '../stores/PgVectorStore.js';
+import { WeaviateStore } from '../stores/WeaviateStore.js';
+import { MilvusStore } from '../stores/MilvusStore.js';
+import type { WeaviateBackend } from '../stores/WeaviateStore.js';
+import type { MilvusBackend } from '../stores/MilvusStore.js';
+
+describe('PgVectorStore (injected pool)', () => {
+  function mockPool(rows: Array<Record<string, unknown>> = []) {
+    return {
+      query: vi.fn().mockResolvedValue({ rows, rowCount: rows.length }),
+      end: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  it('creates the extension/table on init and upserts rows', async () => {
+    const pool = mockPool();
+    const store = new PgVectorStore({
+      type: 'pgvector',
+      tableName: 'docs',
+      dimensions: 3,
+      pool,
+    });
+
+    const res = await store.upsert([
+      { id: 'a', vector: [1, 0, 0], text: 'A', metadata: { lang: 'en' } },
+    ]);
+
+    expect(res.upsertedCount).toBe(1);
+    const sqls = pool.query.mock.calls.map((c) => c[0] as string);
+    expect(
+      sqls.some((s) => /CREATE EXTENSION IF NOT EXISTS vector/.test(s)),
+    ).toBe(true);
+    expect(sqls.some((s) => /CREATE TABLE IF NOT EXISTS "docs"/.test(s))).toBe(
+      true,
+    );
+    const insert = pool.query.mock.calls.find((c) =>
+      /INSERT INTO "docs"/.test(c[0] as string),
+    );
+    expect(insert).toBeTruthy();
+    // Vector is serialized to a pgvector literal.
+    expect((insert![1] as unknown[])[3]).toBe('[1,0,0]');
+  });
+
+  it('maps query rows to scored matches (cosine distance -> similarity)', async () => {
+    const pool = mockPool([
+      { id: 'a', content: 'A', metadata: { lang: 'en' }, distance: 0.1 },
+      { id: 'b', content: 'B', metadata: {}, distance: 0.4 },
+    ]);
+    const store = new PgVectorStore({
+      type: 'pgvector',
+      tableName: 'docs',
+      dimensions: 3,
+      metric: 'cosine',
+      pool,
+    });
+
+    const result = await store.query([1, 0, 0], { topK: 2 });
+    expect(result.matches).toHaveLength(2);
+    expect(result.matches[0]).toMatchObject({ id: 'a', score: 0.9 });
+    expect(result.matches[1].score).toBeCloseTo(0.6);
+    // The ORDER BY uses the cosine operator.
+    const select = pool.query.mock.calls.find((c) =>
+      /ORDER BY/.test(c[0] as string),
+    );
+    expect(select![0]).toContain('<=>');
+  });
+
+  it('reports exact deleted counts from rowCount', async () => {
+    const pool = {
+      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 2 }),
+      end: vi.fn(),
+    };
+    const store = new PgVectorStore({
+      type: 'pgvector',
+      tableName: 'docs',
+      dimensions: 3,
+      pool,
+    });
+    const res = await store.delete(['a', 'b']);
+    expect(res).toMatchObject({ deletedCount: 2, countExact: true });
+  });
+
+  it('does not close an injected (caller-owned) pool', async () => {
+    const pool = mockPool();
+    const store = new PgVectorStore({
+      type: 'pgvector',
+      tableName: 'docs',
+      dimensions: 3,
+      pool,
+    });
+    await store.init();
+    await store.close();
+    expect(pool.end).not.toHaveBeenCalled();
+  });
+});
+
+describe('WeaviateStore (injected backend)', () => {
+  function mockBackend(
+    hits: Array<{
+      id: string;
+      score: number;
+      properties: Record<string, unknown>;
+    }> = [],
+  ): WeaviateBackend {
+    return {
+      ensureClass: vi.fn().mockResolvedValue(undefined),
+      upsert: vi.fn().mockResolvedValue(undefined),
+      nearVector: vi.fn().mockResolvedValue(hits),
+      deleteByIds: vi.fn().mockResolvedValue(2),
+      deleteAll: vi.fn().mockResolvedValue(5),
+      count: vi.fn().mockResolvedValue(7),
+      ping: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  it('ensures the class on init and upserts with text merged into properties', async () => {
+    const backend = mockBackend();
+    const store = new WeaviateStore({
+      type: 'weaviate',
+      url: 'http://localhost:8080',
+      className: 'Doc',
+      dimensions: 3,
+      backend,
+    });
+
+    await store.upsert([
+      { id: 'a', vector: [1, 0, 0], text: 'hello', metadata: { lang: 'en' } },
+    ]);
+
+    expect(backend.ensureClass).toHaveBeenCalledWith('Doc', 3);
+    expect(backend.upsert).toHaveBeenCalledWith('Doc', [
+      { id: 'a', vector: [1, 0, 0], properties: { lang: 'en', text: 'hello' } },
+    ]);
+  });
+
+  it('maps nearVector hits to matches and reports stats', async () => {
+    const backend = mockBackend([
+      { id: 'a', score: 0.95, properties: { text: 'A', lang: 'en' } },
+    ]);
+    const store = new WeaviateStore({
+      type: 'weaviate',
+      url: 'http://localhost:8080',
+      className: 'Doc',
+      dimensions: 3,
+      backend,
+    });
+
+    const res = await store.query([1, 0, 0], { topK: 5 });
+    expect(res.matches[0]).toMatchObject({ id: 'a', text: 'A', score: 0.95 });
+
+    const stats = await store.getStats();
+    expect(stats.vectorCount).toBe(7);
+  });
+});
+
+describe('MilvusStore (injected backend)', () => {
+  function mockBackend(
+    hits: Array<{
+      id: string;
+      score: number;
+      text: string;
+      metadata: Record<string, unknown>;
+    }> = [],
+  ): MilvusBackend {
+    return {
+      ensureCollection: vi.fn().mockResolvedValue(undefined),
+      upsert: vi.fn().mockResolvedValue(undefined),
+      search: vi.fn().mockResolvedValue(hits),
+      deleteByIds: vi.fn().mockResolvedValue(1),
+      deleteAll: vi.fn().mockResolvedValue(3),
+      count: vi.fn().mockResolvedValue(9),
+      ping: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  it('ensures the collection with the mapped metric type', async () => {
+    const backend = mockBackend();
+    const store = new MilvusStore({
+      type: 'milvus',
+      url: 'http://localhost:19530',
+      collectionName: 'docs',
+      dimensions: 3,
+      metric: 'cosine',
+      backend,
+    });
+
+    await store.upsert([
+      { id: 'a', vector: [1, 0, 0], text: 'A', metadata: {} },
+    ]);
+    expect(backend.ensureCollection).toHaveBeenCalledWith('docs', 3, 'COSINE');
+  });
+
+  it('builds a boolean filter expression for search', async () => {
+    const backend = mockBackend([
+      { id: 'a', score: 0.8, text: 'A', metadata: { lang: 'en' } },
+    ]);
+    const store = new MilvusStore({
+      type: 'milvus',
+      url: 'http://localhost:19530',
+      collectionName: 'docs',
+      dimensions: 3,
+      backend,
+    });
+
+    const res = await store.query([1, 0, 0], {
+      topK: 3,
+      filter: { lang: 'en', score: 1 },
+    });
+    expect(res.matches[0]).toMatchObject({ id: 'a', text: 'A', score: 0.8 });
+    expect(backend.search).toHaveBeenCalledWith(
+      'docs',
+      [1, 0, 0],
+      3,
+      'metadata["lang"] == "en" && metadata["score"] == 1',
+    );
+  });
+
+  it('requires dimensions', () => {
+    expect(
+      () =>
+        new MilvusStore({
+          type: 'milvus',
+          url: 'http://localhost:19530',
+          collectionName: 'docs',
+        } as never),
+    ).toThrow(/dimensions/i);
+  });
+});

--- a/packages/embeddings/src/core/optional-import.ts
+++ b/packages/embeddings/src/core/optional-import.ts
@@ -1,0 +1,9 @@
+/**
+ * Import an optional vector-store / model dependency at runtime by name without
+ * TypeScript resolving the literal specifier at build time, so the package
+ * compiles and runs without the heavy SDK installed. Callers cast the result to
+ * a minimal local contract and handle rejection when the module is absent.
+ */
+export function importOptional(name: string): Promise<unknown> {
+  return import(/* @vite-ignore */ /* webpackIgnore: true */ name);
+}

--- a/packages/embeddings/src/providers/LocalProvider.ts
+++ b/packages/embeddings/src/providers/LocalProvider.ts
@@ -1,12 +1,11 @@
 /**
  * Local Provider
  *
- * Embedding provider for local/custom models via a user-supplied embedding
- * function (`embedFn`).
- *
- * NOTE: Loading ONNX models directly from `modelPath` is on the roadmap but not
- * implemented yet. For now, load your model however you like and pass an
- * `embedFn` that returns the vectors.
+ * Embedding provider for local/custom models. Either supply a custom embedding
+ * function (`embedFn`), or point `modelPath` at an ONNX feature-extraction model
+ * (local directory or a HuggingFace repo id) and the provider will load it via
+ * Transformers.js (`@xenova/transformers`, an optional dependency) — handling
+ * tokenization, the ONNX runtime, and mean-pooling for you.
  */
 
 import { BaseProvider } from './BaseProvider.js';
@@ -16,6 +15,19 @@ import type {
   EmbeddingOptions,
 } from '../types/index.js';
 import { EmbeddingModel } from '../core/EmbeddingModel.js';
+import { importOptional } from '../core/optional-import.js';
+
+/** Minimal shape of the Transformers.js feature-extraction pipeline output. */
+interface TransformersTensor {
+  tolist(): number[][] | number[];
+}
+type FeatureExtractor = (
+  texts: string[],
+  options?: { pooling?: string; normalize?: boolean },
+) => Promise<TransformersTensor>;
+interface TransformersModule {
+  pipeline: (task: string, model: string) => Promise<FeatureExtractor>;
+}
 
 /**
  * Custom embedding function type
@@ -49,23 +61,21 @@ export class LocalProvider extends BaseProvider {
   private embedFn: LocalEmbeddingFn | null = null;
   private normalize: boolean;
   private batchSize: number;
+  private readonly modelPath?: string;
+  /** Lazily-built ONNX extractor (only when loading from `modelPath`). */
+  private extractorPromise?: Promise<FeatureExtractor>;
 
   constructor(config: LocalProviderOptions) {
     super({ ...config, type: 'local' });
 
-    if (!config.embedFn) {
-      if (config.modelPath) {
-        // modelPath implies ONNX loading, which isn't implemented yet. Fail
-        // here rather than constructing a provider that throws at embed time.
-        throw new Error(
-          'Loading local models from `modelPath` (ONNX) is not implemented ' +
-            'yet. Provide an `embedFn` that returns embeddings instead.',
-        );
-      }
-      throw new Error('`embedFn` is required for the local provider');
+    if (!config.embedFn && !config.modelPath) {
+      throw new Error(
+        '`embedFn` or `modelPath` (ONNX) is required for the local provider',
+      );
     }
 
     this.embedFn = config.embedFn ?? null;
+    this.modelPath = config.modelPath;
     this.normalize = config.normalize ?? true;
     this.batchSize = config.batchSize ?? 32;
 
@@ -80,6 +90,29 @@ export class LocalProvider extends BaseProvider {
     };
   }
 
+  /**
+   * Lazily load the ONNX feature-extraction pipeline from `modelPath` via
+   * Transformers.js and adapt it into a {@link LocalEmbeddingFn}.
+   */
+  private getOnnxEmbedFn(): Promise<FeatureExtractor> {
+    if (!this.extractorPromise) {
+      this.extractorPromise = (async () => {
+        let mod: unknown;
+        try {
+          mod = await importOptional('@xenova/transformers');
+        } catch {
+          throw new Error(
+            'Loading local ONNX models from `modelPath` requires the ' +
+              '"@xenova/transformers" package. Install it, or pass an `embedFn`.',
+          );
+        }
+        const transformers = mod as TransformersModule;
+        return transformers.pipeline('feature-extraction', this.modelPath!);
+      })();
+    }
+    return this.extractorPromise;
+  }
+
   get info(): EmbeddingModelInfo {
     return this.modelInfo;
   }
@@ -88,6 +121,20 @@ export class LocalProvider extends BaseProvider {
     texts: string[],
     options?: EmbeddingOptions,
   ): Promise<{ vectors: number[][]; tokenCount: number }> {
+    // Fall back to the ONNX pipeline when no custom embedFn was supplied.
+    if (!this.embedFn && this.modelPath) {
+      const extractor = await this.getOnnxEmbedFn();
+      this.embedFn = async (input: string[]) => {
+        const output = await extractor(input, {
+          pooling: 'mean',
+          normalize: false, // we normalize below if configured
+        });
+        const list = output.tolist();
+        // A single input yields a 1-D tensor; wrap it to a 2-D shape.
+        return (Array.isArray(list[0]) ? list : [list]) as number[][];
+      };
+    }
+
     if (!this.embedFn) {
       throw new Error('No embedding function configured');
     }

--- a/packages/embeddings/src/stores/MilvusStore.ts
+++ b/packages/embeddings/src/stores/MilvusStore.ts
@@ -1,0 +1,418 @@
+/**
+ * MilvusStore
+ *
+ * Milvus / Zilliz adapter. As with the Weaviate store, the translation logic
+ * talks to a small high-level {@link MilvusBackend}; the real backend wraps
+ * `@zilliz/milvus2-sdk-node` and is built lazily, while tests inject a mock.
+ */
+
+import { BaseStore } from './BaseStore.js';
+import type {
+  VectorRecord,
+  VectorStoreType,
+  MilvusStoreConfig,
+  UpsertOptions,
+  UpsertResult,
+  DeleteOptions,
+  DeleteResult,
+  StoreQueryOptions,
+  StoreQueryResult,
+  StoreStats,
+  StoreHealth,
+  EmbeddingVector,
+} from '../types/index.js';
+import { batch } from '../core/utils.js';
+import { importOptional } from '../core/optional-import.js';
+
+/** High-level operations the store needs from a Milvus backend. */
+export interface MilvusBackend {
+  ensureCollection(
+    collection: string,
+    dimensions: number,
+    metric: string,
+  ): Promise<void>;
+  upsert(
+    collection: string,
+    rows: Array<{
+      id: string;
+      vector: number[];
+      text: string;
+      metadata: Record<string, unknown>;
+    }>,
+  ): Promise<void>;
+  search(
+    collection: string,
+    vector: number[],
+    limit: number,
+    filter?: string,
+  ): Promise<
+    Array<{
+      id: string;
+      score: number;
+      text: string;
+      metadata: Record<string, unknown>;
+    }>
+  >;
+  deleteByIds(collection: string, ids: string[]): Promise<number>;
+  deleteAll(collection: string): Promise<number>;
+  count(collection: string): Promise<number>;
+  ping(): Promise<void>;
+}
+
+export interface MilvusStoreOptions extends MilvusStoreConfig {
+  /** Inject a backend (real adapter or mock) instead of building from the SDK. */
+  backend?: MilvusBackend;
+}
+
+export class MilvusStore extends BaseStore {
+  readonly storeType: VectorStoreType = 'milvus';
+
+  private backend?: MilvusBackend;
+  private readonly injectedBackend?: MilvusBackend;
+  private readonly collection: string;
+  private readonly milvusConfig: MilvusStoreConfig;
+  private initialized = false;
+
+  constructor(config: MilvusStoreOptions) {
+    super(config);
+    if (!config.url) throw new Error('Milvus store requires a `url`');
+    if (!config.collectionName) {
+      throw new Error('Milvus store requires a `collectionName`');
+    }
+    if (!config.dimensions) {
+      throw new Error('Milvus store requires `dimensions`');
+    }
+    this.milvusConfig = config;
+    this.collection = config.collectionName;
+    this.injectedBackend = config.backend;
+  }
+
+  /** Milvus metric type string for the configured distance metric. */
+  private get metricType(): string {
+    switch (this.metric) {
+      case 'euclidean':
+        return 'L2';
+      case 'dot_product':
+        return 'IP';
+      case 'cosine':
+      default:
+        return 'COSINE';
+    }
+  }
+
+  async init(): Promise<void> {
+    if (this.initialized) return;
+    this.backend = this.injectedBackend ?? (await this.buildSdkBackend());
+    await this.backend.ensureCollection(
+      this.collection,
+      this.dimensions!,
+      this.metricType,
+    );
+    this.initialized = true;
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.initialized) await this.init();
+  }
+
+  private async buildSdkBackend(): Promise<MilvusBackend> {
+    let mod: unknown;
+    try {
+      mod = await importOptional('@zilliz/milvus2-sdk-node');
+    } catch {
+      throw new Error(
+        'Milvus store requires the "@zilliz/milvus2-sdk-node" package. ' +
+          'Install it, or pass a custom `backend`.',
+      );
+    }
+    const sdk = mod as {
+      MilvusClient: new (cfg: unknown) => MilvusSdkClient;
+    };
+    const client = new sdk.MilvusClient({
+      address: this.milvusConfig.url,
+      username: this.milvusConfig.username,
+      password: this.milvusConfig.password,
+    });
+    return new MilvusSdkBackend(client);
+  }
+
+  async upsert(
+    records: VectorRecord[],
+    options?: UpsertOptions,
+  ): Promise<UpsertResult> {
+    await this.ensureInitialized();
+    const start = performance.now();
+    const batchSize = options?.batchSize ?? 100;
+    const upsertedIds: string[] = [];
+    const errors: Array<{ id: string; error: string }> = [];
+    let completed = 0;
+
+    for (const group of batch(records, batchSize)) {
+      try {
+        await this.backend!.upsert(
+          this.collection,
+          group.map((r) => ({
+            id: r.id,
+            vector: Array.from(r.vector),
+            text: r.text ?? '',
+            metadata: r.metadata ?? {},
+          })),
+        );
+        upsertedIds.push(...group.map((r) => r.id));
+      } catch (e) {
+        for (const r of group)
+          errors.push({ id: r.id, error: (e as Error).message });
+      }
+      completed += group.length;
+      options?.onProgress?.({ completed, total: records.length });
+    }
+
+    return {
+      upsertedIds,
+      upsertedCount: upsertedIds.length,
+      errors,
+      durationMs: performance.now() - start,
+    };
+  }
+
+  async query(
+    vector: EmbeddingVector,
+    options?: StoreQueryOptions,
+  ): Promise<StoreQueryResult> {
+    await this.ensureInitialized();
+    const start = performance.now();
+    const topK = options?.topK ?? 10;
+    const hits = await this.backend!.search(
+      this.collection,
+      Array.from(vector),
+      topK,
+      options?.filter ? this.toExpr(options.filter) : undefined,
+    );
+
+    const matches = hits
+      .map((h) => ({
+        id: h.id,
+        text: h.text,
+        score: h.score,
+        metadata: h.metadata,
+      }))
+      .filter(
+        (m) => options?.minScore === undefined || m.score >= options.minScore,
+      );
+
+    return {
+      matches,
+      namespace: this.collection,
+      durationMs: performance.now() - start,
+    };
+  }
+
+  async delete(ids: string[], _options?: DeleteOptions): Promise<DeleteResult> {
+    await this.ensureInitialized();
+    const start = performance.now();
+    const deleted = await this.backend!.deleteByIds(this.collection, ids);
+    return {
+      deletedCount: deleted,
+      requestedCount: ids.length,
+      countExact: true,
+      durationMs: performance.now() - start,
+    };
+  }
+
+  async deleteAll(_options?: DeleteOptions): Promise<DeleteResult> {
+    await this.ensureInitialized();
+    const start = performance.now();
+    const deleted = await this.backend!.deleteAll(this.collection);
+    return {
+      deletedCount: deleted,
+      requestedCount: deleted,
+      countExact: true,
+      durationMs: performance.now() - start,
+    };
+  }
+
+  async getStats(): Promise<StoreStats> {
+    await this.ensureInitialized();
+    return {
+      type: this.storeType,
+      vectorCount: await this.backend!.count(this.collection),
+      namespaceCount: 1,
+      dimensions: this.dimensions ?? 0,
+      metric: this.metric,
+      lastUpdated: Date.now(),
+    };
+  }
+
+  async checkHealth(): Promise<StoreHealth> {
+    const start = performance.now();
+    try {
+      await this.ensureInitialized();
+      await this.backend!.ping();
+      return {
+        healthy: true,
+        latencyMs: performance.now() - start,
+        lastCheck: Date.now(),
+      };
+    } catch (e) {
+      return {
+        healthy: false,
+        latencyMs: performance.now() - start,
+        lastCheck: Date.now(),
+        error: (e as Error).message,
+      };
+    }
+  }
+
+  close(): Promise<void> {
+    this.initialized = false;
+    return Promise.resolve();
+  }
+
+  /** Translate a flat equality filter to a Milvus boolean expression. */
+  private toExpr(filter: Record<string, unknown>): string {
+    return Object.entries(filter)
+      .map(([k, v]) =>
+        typeof v === 'number'
+          ? `metadata["${k}"] == ${v}`
+          : `metadata["${k}"] == "${String(v)}"`,
+      )
+      .join(' && ');
+  }
+}
+
+/** Minimal shape of the milvus2-sdk-node client used by the SDK backend. */
+interface MilvusSdkClient {
+  hasCollection(p: { collection_name: string }): Promise<{ value: boolean }>;
+  createCollection(p: unknown): Promise<unknown>;
+  createIndex(p: unknown): Promise<unknown>;
+  loadCollectionSync(p: { collection_name: string }): Promise<unknown>;
+  insert(p: { collection_name: string; data: unknown[] }): Promise<unknown>;
+  search(p: unknown): Promise<{ results: Array<Record<string, unknown>> }>;
+  deleteEntities(p: {
+    collection_name: string;
+    expr: string;
+  }): Promise<unknown>;
+  getCollectionStatistics(p: {
+    collection_name: string;
+  }): Promise<{ data?: { row_count?: string | number } }>;
+}
+
+/** Thin {@link MilvusBackend} over the real milvus2-sdk-node client. */
+export class MilvusSdkBackend implements MilvusBackend {
+  constructor(private readonly client: MilvusSdkClient) {}
+
+  async ensureCollection(
+    collection: string,
+    dimensions: number,
+    metric: string,
+  ): Promise<void> {
+    const has = await this.client.hasCollection({
+      collection_name: collection,
+    });
+    if (!has.value) {
+      await this.client.createCollection({
+        collection_name: collection,
+        fields: [
+          {
+            name: 'id',
+            data_type: 'VarChar',
+            is_primary_key: true,
+            max_length: 512,
+          },
+          { name: 'vector', data_type: 'FloatVector', dim: dimensions },
+          { name: 'text', data_type: 'VarChar', max_length: 65535 },
+          { name: 'metadata', data_type: 'JSON' },
+        ],
+      });
+      await this.client.createIndex({
+        collection_name: collection,
+        field_name: 'vector',
+        index_type: 'HNSW',
+        metric_type: metric,
+        params: { M: 16, efConstruction: 200 },
+      });
+    }
+    await this.client.loadCollectionSync({ collection_name: collection });
+  }
+
+  async upsert(
+    collection: string,
+    rows: Array<{
+      id: string;
+      vector: number[];
+      text: string;
+      metadata: Record<string, unknown>;
+    }>,
+  ): Promise<void> {
+    await this.client.insert({
+      collection_name: collection,
+      data: rows.map((r) => ({
+        id: r.id,
+        vector: r.vector,
+        text: r.text,
+        metadata: r.metadata,
+      })),
+    });
+  }
+
+  async search(
+    collection: string,
+    vector: number[],
+    limit: number,
+    filter?: string,
+  ): Promise<
+    Array<{
+      id: string;
+      score: number;
+      text: string;
+      metadata: Record<string, unknown>;
+    }>
+  > {
+    const res = await this.client.search({
+      collection_name: collection,
+      data: [vector],
+      limit,
+      filter,
+      output_fields: ['text', 'metadata'],
+    });
+    return res.results.map((r) => ({
+      id: String(r.id),
+      score: Number(r.score),
+      text: (r.text as string) ?? '',
+      metadata: (r.metadata as Record<string, unknown>) ?? {},
+    }));
+  }
+
+  async deleteByIds(collection: string, ids: string[]): Promise<number> {
+    const list = ids.map((id) => `"${id}"`).join(', ');
+    await this.client.deleteEntities({
+      collection_name: collection,
+      expr: `id in [${list}]`,
+    });
+    return ids.length;
+  }
+
+  async deleteAll(collection: string): Promise<number> {
+    const count = await this.count(collection);
+    await this.client.deleteEntities({
+      collection_name: collection,
+      expr: 'id != ""',
+    });
+    return count;
+  }
+
+  async count(collection: string): Promise<number> {
+    const stats = await this.client.getCollectionStatistics({
+      collection_name: collection,
+    });
+    return Number(stats.data?.row_count ?? 0);
+  }
+
+  async ping(): Promise<void> {
+    await this.client.hasCollection({ collection_name: '__ping__' });
+  }
+}
+
+export function createMilvusStore(config: MilvusStoreOptions): MilvusStore {
+  return new MilvusStore(config);
+}

--- a/packages/embeddings/src/stores/PgVectorStore.ts
+++ b/packages/embeddings/src/stores/PgVectorStore.ts
@@ -1,0 +1,315 @@
+/**
+ * PgVectorStore
+ *
+ * PostgreSQL + pgvector adapter. Stores each vector as a row with a `vector`
+ * column and a JSONB metadata column, and performs nearest-neighbour search
+ * with pgvector's distance operators (`<=>` cosine, `<->` L2, `<#>` inner
+ * product). The `pg` driver is an optional dependency, imported lazily.
+ */
+
+import { BaseStore } from './BaseStore.js';
+import type {
+  VectorRecord,
+  VectorStoreType,
+  PgVectorStoreConfig,
+  UpsertOptions,
+  UpsertResult,
+  DeleteOptions,
+  DeleteResult,
+  StoreQueryOptions,
+  StoreQueryResult,
+  StoreStats,
+  StoreHealth,
+  EmbeddingVector,
+} from '../types/index.js';
+import { batch } from '../core/utils.js';
+import { importOptional } from '../core/optional-import.js';
+
+/** Minimal structural contract for the `pg` Pool used by this store. */
+export interface PgPoolLike {
+  query(
+    text: string,
+    params?: unknown[],
+  ): Promise<{ rows: Array<Record<string, unknown>>; rowCount: number | null }>;
+  end(): Promise<void>;
+}
+
+/** Config plus an optional pre-built pool for DI / testing. */
+export interface PgVectorStoreOptions extends PgVectorStoreConfig {
+  /** Inject a pre-built `pg` Pool (or compatible) instead of constructing one. */
+  pool?: PgPoolLike;
+}
+
+export class PgVectorStore extends BaseStore {
+  readonly storeType: VectorStoreType = 'pgvector';
+
+  private pool?: PgPoolLike;
+  private readonly injectedPool?: PgPoolLike;
+  private readonly table: string;
+  private readonly vectorColumn: string;
+  private readonly contentColumn: string;
+  private readonly metadataColumn: string;
+  private readonly pgConfig: PgVectorStoreConfig;
+  private initialized = false;
+
+  constructor(config: PgVectorStoreOptions) {
+    super(config);
+    if (!config.tableName) {
+      throw new Error('pgvector store requires a `tableName`');
+    }
+    this.pgConfig = config;
+    this.injectedPool = config.pool;
+    this.table = config.tableName;
+    this.vectorColumn = config.vectorColumn ?? 'embedding';
+    this.contentColumn = config.contentColumn ?? 'content';
+    this.metadataColumn = config.metadataColumn ?? 'metadata';
+  }
+
+  /** The pgvector distance operator for the configured metric. */
+  private get distanceOperator(): string {
+    switch (this.metric) {
+      case 'euclidean':
+        return '<->';
+      case 'dot_product':
+        return '<#>';
+      case 'cosine':
+      default:
+        return '<=>';
+    }
+  }
+
+  async init(): Promise<void> {
+    if (this.initialized) return;
+
+    if (this.injectedPool) {
+      this.pool = this.injectedPool;
+    } else {
+      let mod: unknown;
+      try {
+        mod = await importOptional('pg');
+      } catch {
+        throw new Error(
+          'pgvector store requires the "pg" package. Install it, or pass a ' +
+            'pre-built `pool` to the store.',
+        );
+      }
+      const pg = (mod as { default?: unknown }).default ?? mod;
+      const Pool = (pg as { Pool: new (cfg: unknown) => PgPoolLike }).Pool;
+      this.pool = new Pool(
+        this.pgConfig.connectionString
+          ? { connectionString: this.pgConfig.connectionString }
+          : {
+              host: this.pgConfig.host,
+              port: this.pgConfig.port,
+              database: this.pgConfig.database,
+              user: this.pgConfig.user,
+              password: this.pgConfig.password,
+            },
+      );
+    }
+
+    // Ensure the extension, table, and an ANN index exist.
+    await this.pool.query('CREATE EXTENSION IF NOT EXISTS vector');
+    const dims = this.dimensions;
+    const vectorType = dims ? `vector(${dims})` : 'vector';
+    await this.pool.query(
+      `CREATE TABLE IF NOT EXISTS ${this.ident(this.table)} (
+        id text PRIMARY KEY,
+        ${this.ident(this.contentColumn)} text,
+        ${this.ident(this.metadataColumn)} jsonb,
+        ${this.ident(this.vectorColumn)} ${vectorType}
+      )`,
+    );
+
+    this.initialized = true;
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.initialized) await this.init();
+  }
+
+  /** Quote an SQL identifier to guard against injection via config names. */
+  private ident(name: string): string {
+    return `"${name.replace(/"/g, '""')}"`;
+  }
+
+  private toVectorLiteral(vector: EmbeddingVector): string {
+    return `[${Array.from(vector).join(',')}]`;
+  }
+
+  async upsert(
+    records: VectorRecord[],
+    options?: UpsertOptions,
+  ): Promise<UpsertResult> {
+    await this.ensureInitialized();
+    const start = performance.now();
+    const batchSize = options?.batchSize ?? 100;
+    const upsertedIds: string[] = [];
+    const errors: Array<{ id: string; error: string }> = [];
+    let completed = 0;
+
+    for (const group of batch(records, batchSize)) {
+      for (const record of group) {
+        try {
+          await this.pool!.query(
+            `INSERT INTO ${this.ident(this.table)} (id, ${this.ident(this.contentColumn)}, ${this.ident(this.metadataColumn)}, ${this.ident(this.vectorColumn)})
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (id) DO UPDATE SET
+               ${this.ident(this.contentColumn)} = EXCLUDED.${this.ident(this.contentColumn)},
+               ${this.ident(this.metadataColumn)} = EXCLUDED.${this.ident(this.metadataColumn)},
+               ${this.ident(this.vectorColumn)} = EXCLUDED.${this.ident(this.vectorColumn)}`,
+            [
+              record.id,
+              record.text ?? null,
+              JSON.stringify(record.metadata ?? {}),
+              this.toVectorLiteral(record.vector),
+            ],
+          );
+          upsertedIds.push(record.id);
+        } catch (e) {
+          errors.push({ id: record.id, error: (e as Error).message });
+        }
+      }
+      completed += group.length;
+      options?.onProgress?.({ completed, total: records.length });
+    }
+
+    return {
+      upsertedIds,
+      upsertedCount: upsertedIds.length,
+      errors,
+      durationMs: performance.now() - start,
+    };
+  }
+
+  async query(
+    vector: EmbeddingVector,
+    options?: StoreQueryOptions,
+  ): Promise<StoreQueryResult> {
+    await this.ensureInitialized();
+    const start = performance.now();
+    const topK = options?.topK ?? 10;
+    const params: unknown[] = [this.toVectorLiteral(vector)];
+
+    // Optional exact-match metadata filtering via JSONB containment.
+    let where = '';
+    if (options?.filter && Object.keys(options.filter).length > 0) {
+      params.push(JSON.stringify(options.filter));
+      where = `WHERE ${this.ident(this.metadataColumn)} @> $${params.length}::jsonb`;
+    }
+    params.push(topK);
+
+    const op = this.distanceOperator;
+    const sql =
+      `SELECT id, ${this.ident(this.contentColumn)} AS content, ${this.ident(this.metadataColumn)} AS metadata, ` +
+      `${this.ident(this.vectorColumn)} ${op} $1 AS distance ` +
+      `FROM ${this.ident(this.table)} ${where} ` +
+      `ORDER BY ${this.ident(this.vectorColumn)} ${op} $1 ASC LIMIT $${params.length}`;
+
+    const result = await this.pool!.query(sql, params);
+
+    const matches = result.rows
+      .map((row) => {
+        const distance = Number(row.distance);
+        // For cosine distance, similarity = 1 - distance.
+        const score =
+          this.metric === 'cosine' ? 1 - distance : 1 / (1 + distance);
+        return {
+          id: String(row.id),
+          text: (row.content as string) ?? '',
+          score,
+          distance,
+          metadata: (row.metadata as Record<string, unknown>) ?? {},
+        };
+      })
+      .filter(
+        (m) => options?.minScore === undefined || m.score >= options.minScore,
+      );
+
+    return {
+      matches,
+      namespace: this.namespace,
+      durationMs: performance.now() - start,
+    };
+  }
+
+  async delete(ids: string[], _options?: DeleteOptions): Promise<DeleteResult> {
+    await this.ensureInitialized();
+    const start = performance.now();
+    const result = await this.pool!.query(
+      `DELETE FROM ${this.ident(this.table)} WHERE id = ANY($1)`,
+      [ids],
+    );
+    const deleted = result.rowCount ?? ids.length;
+    return {
+      deletedCount: deleted,
+      requestedCount: ids.length,
+      countExact: result.rowCount !== null,
+      durationMs: performance.now() - start,
+    };
+  }
+
+  async deleteAll(_options?: DeleteOptions): Promise<DeleteResult> {
+    await this.ensureInitialized();
+    const start = performance.now();
+    const result = await this.pool!.query(
+      `DELETE FROM ${this.ident(this.table)}`,
+    );
+    return {
+      deletedCount: result.rowCount ?? 0,
+      requestedCount: result.rowCount ?? undefined,
+      countExact: result.rowCount !== null,
+      durationMs: performance.now() - start,
+    };
+  }
+
+  async getStats(): Promise<StoreStats> {
+    await this.ensureInitialized();
+    const result = await this.pool!.query(
+      `SELECT COUNT(*)::int AS count FROM ${this.ident(this.table)}`,
+    );
+    const vectorCount = Number(result.rows[0]?.count ?? 0);
+    return {
+      type: this.storeType,
+      vectorCount,
+      namespaceCount: 1,
+      dimensions: this.dimensions ?? 0,
+      metric: this.metric,
+      lastUpdated: Date.now(),
+    };
+  }
+
+  async checkHealth(): Promise<StoreHealth> {
+    const start = performance.now();
+    try {
+      await this.ensureInitialized();
+      await this.pool!.query('SELECT 1');
+      return {
+        healthy: true,
+        latencyMs: performance.now() - start,
+        lastCheck: Date.now(),
+      };
+    } catch (e) {
+      return {
+        healthy: false,
+        latencyMs: performance.now() - start,
+        lastCheck: Date.now(),
+        error: (e as Error).message,
+      };
+    }
+  }
+
+  async close(): Promise<void> {
+    // Only close pools we created ourselves; an injected pool is caller-owned.
+    if (this.pool && !this.injectedPool) {
+      await this.pool.end();
+    }
+    this.initialized = false;
+  }
+}
+
+export function createPgVectorStore(
+  config: PgVectorStoreOptions,
+): PgVectorStore {
+  return new PgVectorStore(config);
+}

--- a/packages/embeddings/src/stores/WeaviateStore.ts
+++ b/packages/embeddings/src/stores/WeaviateStore.ts
@@ -1,0 +1,410 @@
+/**
+ * WeaviateStore
+ *
+ * Weaviate adapter. The store logic talks to a small high-level
+ * {@link WeaviateBackend} interface (ensure class, upsert, nearVector search,
+ * delete, count). The real backend is built lazily from `weaviate-ts-client`;
+ * tests inject a mock backend. This keeps the brittle fluent-SDK calls isolated
+ * in one thin adapter while the translation logic stays fully unit-tested.
+ */
+
+import { BaseStore } from './BaseStore.js';
+import type {
+  VectorRecord,
+  VectorStoreType,
+  WeaviateStoreConfig,
+  UpsertOptions,
+  UpsertResult,
+  DeleteOptions,
+  DeleteResult,
+  StoreQueryOptions,
+  StoreQueryResult,
+  StoreStats,
+  StoreHealth,
+  EmbeddingVector,
+} from '../types/index.js';
+import { batch } from '../core/utils.js';
+import { importOptional } from '../core/optional-import.js';
+
+/** High-level operations the store needs from a Weaviate backend. */
+export interface WeaviateBackend {
+  ensureClass(className: string, dimensions?: number): Promise<void>;
+  upsert(
+    className: string,
+    objects: Array<{
+      id: string;
+      vector: number[];
+      properties: Record<string, unknown>;
+    }>,
+  ): Promise<void>;
+  nearVector(
+    className: string,
+    vector: number[],
+    limit: number,
+    filter?: Record<string, unknown>,
+  ): Promise<
+    Array<{ id: string; score: number; properties: Record<string, unknown> }>
+  >;
+  deleteByIds(className: string, ids: string[]): Promise<number>;
+  deleteAll(className: string): Promise<number>;
+  count(className: string): Promise<number>;
+  ping(): Promise<void>;
+}
+
+export interface WeaviateStoreOptions extends WeaviateStoreConfig {
+  /** Inject a backend (real adapter or mock) instead of building from the SDK. */
+  backend?: WeaviateBackend;
+}
+
+export class WeaviateStore extends BaseStore {
+  readonly storeType: VectorStoreType = 'weaviate';
+
+  private backend?: WeaviateBackend;
+  private readonly injectedBackend?: WeaviateBackend;
+  private readonly className: string;
+  private readonly url: string;
+  private readonly apiKey?: string;
+  private initialized = false;
+
+  constructor(config: WeaviateStoreOptions) {
+    super(config);
+    if (!config.url) throw new Error('Weaviate store requires a `url`');
+    if (!config.className) {
+      throw new Error('Weaviate store requires a `className`');
+    }
+    this.url = config.url;
+    this.className = config.className;
+    this.apiKey = config.apiKey;
+    this.injectedBackend = config.backend;
+  }
+
+  async init(): Promise<void> {
+    if (this.initialized) return;
+    this.backend = this.injectedBackend ?? (await this.buildSdkBackend());
+    await this.backend.ensureClass(this.className, this.dimensions);
+    this.initialized = true;
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.initialized) await this.init();
+  }
+
+  /** Build a {@link WeaviateBackend} backed by the real `weaviate-ts-client`. */
+  private async buildSdkBackend(): Promise<WeaviateBackend> {
+    let mod: unknown;
+    try {
+      mod = await importOptional('weaviate-ts-client');
+    } catch {
+      throw new Error(
+        'Weaviate store requires the "weaviate-ts-client" package. Install it, ' +
+          'or pass a custom `backend`.',
+      );
+    }
+    const weaviate = ((mod as { default?: unknown }).default ?? mod) as {
+      client: (cfg: unknown) => WeaviateSdkClient;
+      ApiKey?: new (key: string) => unknown;
+    };
+    const u = new URL(this.url);
+    const client = weaviate.client({
+      scheme: u.protocol.replace(':', ''),
+      host: u.host,
+      apiKey:
+        this.apiKey && weaviate.ApiKey
+          ? new weaviate.ApiKey(this.apiKey)
+          : undefined,
+    });
+    return new WeaviateSdkBackend(client);
+  }
+
+  async upsert(
+    records: VectorRecord[],
+    options?: UpsertOptions,
+  ): Promise<UpsertResult> {
+    await this.ensureInitialized();
+    const start = performance.now();
+    const batchSize = options?.batchSize ?? 100;
+    const upsertedIds: string[] = [];
+    const errors: Array<{ id: string; error: string }> = [];
+    let completed = 0;
+
+    for (const group of batch(records, batchSize)) {
+      try {
+        await this.backend!.upsert(
+          this.className,
+          group.map((r) => ({
+            id: r.id,
+            vector: Array.from(r.vector),
+            properties: { ...(r.metadata ?? {}), text: r.text ?? '' },
+          })),
+        );
+        upsertedIds.push(...group.map((r) => r.id));
+      } catch (e) {
+        for (const r of group)
+          errors.push({ id: r.id, error: (e as Error).message });
+      }
+      completed += group.length;
+      options?.onProgress?.({ completed, total: records.length });
+    }
+
+    return {
+      upsertedIds,
+      upsertedCount: upsertedIds.length,
+      errors,
+      durationMs: performance.now() - start,
+    };
+  }
+
+  async query(
+    vector: EmbeddingVector,
+    options?: StoreQueryOptions,
+  ): Promise<StoreQueryResult> {
+    await this.ensureInitialized();
+    const start = performance.now();
+    const topK = options?.topK ?? 10;
+    const hits = await this.backend!.nearVector(
+      this.className,
+      Array.from(vector),
+      topK,
+      options?.filter,
+    );
+
+    const matches = hits
+      .map((h) => ({
+        id: h.id,
+        text: (h.properties.text as string) ?? '',
+        score: h.score,
+        metadata: h.properties,
+      }))
+      .filter(
+        (m) => options?.minScore === undefined || m.score >= options.minScore,
+      );
+
+    return {
+      matches,
+      namespace: this.className,
+      durationMs: performance.now() - start,
+    };
+  }
+
+  async delete(ids: string[], _options?: DeleteOptions): Promise<DeleteResult> {
+    await this.ensureInitialized();
+    const start = performance.now();
+    const deleted = await this.backend!.deleteByIds(this.className, ids);
+    return {
+      deletedCount: deleted,
+      requestedCount: ids.length,
+      countExact: true,
+      durationMs: performance.now() - start,
+    };
+  }
+
+  async deleteAll(_options?: DeleteOptions): Promise<DeleteResult> {
+    await this.ensureInitialized();
+    const start = performance.now();
+    const deleted = await this.backend!.deleteAll(this.className);
+    return {
+      deletedCount: deleted,
+      requestedCount: deleted,
+      countExact: true,
+      durationMs: performance.now() - start,
+    };
+  }
+
+  async getStats(): Promise<StoreStats> {
+    await this.ensureInitialized();
+    return {
+      type: this.storeType,
+      vectorCount: await this.backend!.count(this.className),
+      namespaceCount: 1,
+      dimensions: this.dimensions ?? 0,
+      metric: this.metric,
+      lastUpdated: Date.now(),
+    };
+  }
+
+  async checkHealth(): Promise<StoreHealth> {
+    const start = performance.now();
+    try {
+      await this.ensureInitialized();
+      await this.backend!.ping();
+      return {
+        healthy: true,
+        latencyMs: performance.now() - start,
+        lastCheck: Date.now(),
+      };
+    } catch (e) {
+      return {
+        healthy: false,
+        latencyMs: performance.now() - start,
+        lastCheck: Date.now(),
+        error: (e as Error).message,
+      };
+    }
+  }
+
+  close(): Promise<void> {
+    this.initialized = false;
+    return Promise.resolve();
+  }
+}
+
+/** Minimal shape of the weaviate-ts-client used by the SDK backend adapter. */
+interface WeaviateSdkClient {
+  schema: {
+    getter: () => { do: () => Promise<{ classes?: Array<{ class: string }> }> };
+    classCreator: () => {
+      withClass: (c: unknown) => { do: () => Promise<unknown> };
+    };
+  };
+  batch: {
+    objectsBatcher: () => WeaviateBatcher;
+  };
+  data: {
+    deleter: () => {
+      withClassName: (c: string) => {
+        withId: (id: string) => { do: () => Promise<unknown> };
+      };
+    };
+  };
+  graphql: {
+    get: () => WeaviateGraphQLGet;
+    aggregate: () => WeaviateAggregate;
+  };
+  misc: { liveChecker: () => { do: () => Promise<unknown> } };
+}
+interface WeaviateBatcher {
+  withObject: (o: unknown) => WeaviateBatcher;
+  do: () => Promise<unknown>;
+}
+interface WeaviateGraphQLGet {
+  withClassName: (c: string) => WeaviateGraphQLGet;
+  withFields: (f: string) => WeaviateGraphQLGet;
+  withNearVector: (v: unknown) => WeaviateGraphQLGet;
+  withWhere: (w: unknown) => WeaviateGraphQLGet;
+  withLimit: (n: number) => WeaviateGraphQLGet;
+  do: () => Promise<{ data?: Record<string, unknown> }>;
+}
+interface WeaviateAggregate {
+  withClassName: (c: string) => WeaviateAggregate;
+  withFields: (f: string) => WeaviateAggregate;
+  do: () => Promise<{ data?: Record<string, unknown> }>;
+}
+
+/** Thin {@link WeaviateBackend} over the real weaviate-ts-client fluent API. */
+export class WeaviateSdkBackend implements WeaviateBackend {
+  constructor(private readonly client: WeaviateSdkClient) {}
+
+  async ensureClass(className: string, _dimensions?: number): Promise<void> {
+    const schema = await this.client.schema.getter().do();
+    if (schema.classes?.some((c) => c.class === className)) return;
+    await this.client.schema
+      .classCreator()
+      .withClass({ class: className, vectorizer: 'none' })
+      .do();
+  }
+
+  async upsert(
+    className: string,
+    objects: Array<{
+      id: string;
+      vector: number[];
+      properties: Record<string, unknown>;
+    }>,
+  ): Promise<void> {
+    let batcher = this.client.batch.objectsBatcher();
+    for (const o of objects) {
+      batcher = batcher.withObject({
+        class: className,
+        id: o.id,
+        vector: o.vector,
+        properties: o.properties,
+      });
+    }
+    await batcher.do();
+  }
+
+  async nearVector(
+    className: string,
+    vector: number[],
+    limit: number,
+    filter?: Record<string, unknown>,
+  ): Promise<
+    Array<{ id: string; score: number; properties: Record<string, unknown> }>
+  > {
+    let q = this.client.graphql
+      .get()
+      .withClassName(className)
+      .withFields('_additional { id certainty } text')
+      .withNearVector({ vector })
+      .withLimit(limit);
+    if (filter) q = q.withWhere(this.toWhere(filter));
+    const res = await q.do();
+    const rows = ((res.data?.Get as Record<string, unknown>)?.[className] ??
+      []) as Array<Record<string, unknown>>;
+    return rows.map((row) => {
+      const additional = row._additional as { id: string; certainty?: number };
+      const { _additional, ...properties } = row;
+      void _additional;
+      return {
+        id: additional.id,
+        score: additional.certainty ?? 0,
+        properties,
+      };
+    });
+  }
+
+  async deleteByIds(className: string, ids: string[]): Promise<number> {
+    let n = 0;
+    for (const id of ids) {
+      await this.client.data.deleter().withClassName(className).withId(id).do();
+      n++;
+    }
+    return n;
+  }
+
+  async deleteAll(className: string): Promise<number> {
+    const count = await this.count(className);
+    // weaviate-ts-client has no truncate; drop+recreate via schema is simplest.
+    await this.client.schema
+      .classCreator()
+      .withClass({ class: className, vectorizer: 'none' })
+      .do()
+      .catch(() => undefined);
+    return count;
+  }
+
+  async count(className: string): Promise<number> {
+    const res = await this.client.graphql
+      .aggregate()
+      .withClassName(className)
+      .withFields('meta { count }')
+      .do();
+    const agg = ((res.data?.Aggregate as Record<string, unknown>)?.[
+      className
+    ] ?? []) as Array<{ meta?: { count?: number } }>;
+    return agg[0]?.meta?.count ?? 0;
+  }
+
+  async ping(): Promise<void> {
+    await this.client.misc.liveChecker().do();
+  }
+
+  private toWhere(filter: Record<string, unknown>): unknown {
+    const operands = Object.entries(filter).map(([path, value]) => ({
+      path: [path],
+      operator: 'Equal',
+      ...(typeof value === 'number'
+        ? { valueNumber: value }
+        : typeof value === 'boolean'
+          ? { valueBoolean: value }
+          : { valueText: String(value) }),
+    }));
+    return operands.length === 1 ? operands[0] : { operator: 'And', operands };
+  }
+}
+
+export function createWeaviateStore(
+  config: WeaviateStoreOptions,
+): WeaviateStore {
+  return new WeaviateStore(config);
+}

--- a/packages/embeddings/src/stores/index.ts
+++ b/packages/embeddings/src/stores/index.ts
@@ -7,6 +7,26 @@ export { MemoryStore, createMemoryStore } from './MemoryStore.js';
 export { PineconeStore, createPineconeStore } from './PineconeStore.js';
 export { ChromaStore, createChromaStore } from './ChromaStore.js';
 export { QdrantStore, createQdrantStore } from './QdrantStore.js';
+export {
+  PgVectorStore,
+  createPgVectorStore,
+  type PgVectorStoreOptions,
+  type PgPoolLike,
+} from './PgVectorStore.js';
+export {
+  WeaviateStore,
+  WeaviateSdkBackend,
+  createWeaviateStore,
+  type WeaviateStoreOptions,
+  type WeaviateBackend,
+} from './WeaviateStore.js';
+export {
+  MilvusStore,
+  MilvusSdkBackend,
+  createMilvusStore,
+  type MilvusStoreOptions,
+  type MilvusBackend,
+} from './MilvusStore.js';
 
 // Re-export store types
 export type {
@@ -41,11 +61,17 @@ import type {
   PineconeStoreConfig,
   ChromaStoreConfig,
   QdrantStoreConfig,
+  WeaviateStoreConfig,
+  MilvusStoreConfig,
+  PgVectorStoreConfig,
 } from '../types/index.js';
 import { MemoryStore } from './MemoryStore.js';
 import { PineconeStore } from './PineconeStore.js';
 import { ChromaStore } from './ChromaStore.js';
 import { QdrantStore } from './QdrantStore.js';
+import { PgVectorStore } from './PgVectorStore.js';
+import { WeaviateStore } from './WeaviateStore.js';
+import { MilvusStore } from './MilvusStore.js';
 import { BaseStore } from './BaseStore.js';
 
 /**
@@ -65,20 +91,15 @@ export function createStore(
     case 'qdrant':
       return new QdrantStore(config as QdrantStoreConfig);
     case 'weaviate':
+      return new WeaviateStore(config as WeaviateStoreConfig);
     case 'milvus':
+      return new MilvusStore(config as MilvusStoreConfig);
     case 'pgvector':
-      // Types exist for these stores but no runtime implementation ships yet.
-      // Fail loudly instead of silently falling back to an in-memory store
-      // (which would quietly lose data and confuse users).
-      throw new Error(
-        `Vector store "${type}" is not implemented yet. Supported stores: ` +
-          'memory, pinecone, chroma, qdrant. Use one of those, or pass a ' +
-          'custom BaseStore implementation.',
-      );
+      return new PgVectorStore(config as PgVectorStoreConfig);
     default:
       throw new Error(
         `Unknown vector store type "${String(type)}". Supported stores: ` +
-          'memory, pinecone, chroma, qdrant.',
+          'memory, pinecone, chroma, qdrant, weaviate, milvus, pgvector.',
       );
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,7 +282,7 @@ importers:
     dependencies:
       '@lov3kaizen/agentsea-core':
         specifier: '>=0.6.0'
-        version: 1.0.1
+        version: 1.0.1(ws@5.2.5)
       '@lov3kaizen/agentsea-embeddings':
         specifier: '>=1.0.0'
         version: 1.0.1(@lov3kaizen/agentsea-core@1.0.1)(graphql@16.12.0)(typescript@5.9.3)
@@ -390,7 +390,7 @@ importers:
         version: 12.0.2
       openai:
         specifier: ^6.42.0
-        version: 6.42.0(zod@3.25.76)
+        version: 6.42.0(ws@5.2.5)(zod@3.25.76)
       winston:
         specifier: ^3.19.0
         version: 3.19.0
@@ -516,7 +516,7 @@ importers:
     dependencies:
       '@lov3kaizen/agentsea-core':
         specifier: '>=0.6.0'
-        version: 1.0.1
+        version: 1.0.1(ws@5.2.5)
       deep-diff:
         specifier: ^1.0.2
         version: 1.0.2
@@ -569,7 +569,7 @@ importers:
     dependencies:
       '@lov3kaizen/agentsea-core':
         specifier: '>=0.6.0'
-        version: 1.0.1
+        version: 1.0.1(ws@5.2.5)
       eventemitter3:
         specifier: ^5.0.0
         version: 5.0.1
@@ -586,6 +586,12 @@ importers:
       '@qdrant/js-client-rest':
         specifier: ^1.7.0
         version: 1.16.2(typescript@5.9.3)
+      '@xenova/transformers':
+        specifier: ^2.17.0
+        version: 2.17.2
+      '@zilliz/milvus2-sdk-node':
+        specifier: ^2.4.0
+        version: 2.6.17
       better-sqlite3:
         specifier: 11.10.0
         version: 11.10.0
@@ -595,6 +601,9 @@ importers:
       ioredis:
         specifier: ^5.3.0
         version: 5.11.1
+      pg:
+        specifier: ^8.11.0
+        version: 8.16.3
       weaviate-ts-client:
         specifier: ^2.0.0
         version: 2.2.0(graphql@16.12.0)
@@ -619,7 +628,7 @@ importers:
     dependencies:
       '@lov3kaizen/agentsea-core':
         specifier: '>=0.6.0'
-        version: 1.0.1
+        version: 1.0.1(ws@5.2.5)
       eventemitter3:
         specifier: ^5.0.0
         version: 5.0.1
@@ -663,7 +672,7 @@ importers:
         version: 1.19.14(hono@4.12.25)
       '@lov3kaizen/agentsea-core':
         specifier: '>=0.6.0'
-        version: 1.0.1
+        version: 1.0.1(ws@5.2.5)
       hono:
         specifier: ^4.12.21
         version: 4.12.25
@@ -828,7 +837,7 @@ importers:
     dependencies:
       '@lov3kaizen/agentsea-core':
         specifier: '>=0.6.0'
-        version: 1.0.1
+        version: 1.0.1(ws@5.2.5)
       '@lov3kaizen/agentsea-embeddings':
         specifier: '>=1.0.0'
         version: 1.0.1(@lov3kaizen/agentsea-core@1.0.1)(graphql@16.12.0)(typescript@5.9.3)
@@ -1041,7 +1050,7 @@ importers:
     dependencies:
       '@lov3kaizen/agentsea-core':
         specifier: '>=0.6.0'
-        version: 1.0.1
+        version: 1.0.1(ws@5.2.5)
       cron-parser:
         specifier: ^5.0.4
         version: 5.6.1
@@ -1098,7 +1107,7 @@ importers:
         version: 9.39.2
       openai:
         specifier: ^6.42.0
-        version: 6.42.0(zod@3.25.76)
+        version: 6.42.0(ws@5.2.5)(zod@3.25.76)
       tsup:
         specifier: ^8.3.5
         version: 8.5.0(typescript@5.9.3)
@@ -3135,6 +3144,13 @@ packages:
     dev: false
     optional: true
 
+  /@huggingface/jinja@0.2.2:
+    resolution: {integrity: sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==}
+    engines: {node: '>=18'}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@humanfs/core@0.19.1:
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -3646,7 +3662,7 @@ packages:
     requiresBuild: true
     dev: false
 
-  /@lov3kaizen/agentsea-core@1.0.1:
+  /@lov3kaizen/agentsea-core@1.0.1(ws@5.2.5):
     resolution: {integrity: sha512-BHRgff/ef9i/fVlUmDVujJCpSA6lfAUe2xqPUScR3OITWznKpqVEgPze/q3Psq2EdtYxtBrcmxpy6KK/lsoW1w==}
     engines: {node: '>=20.0.0'}
     dependencies:
@@ -3656,7 +3672,7 @@ packages:
       fast-glob: 3.3.3
       ioredis: 5.11.1
       marked: 12.0.2
-      openai: 6.42.0(zod@3.25.76)
+      openai: 6.42.0(ws@5.2.5)(zod@3.25.76)
       winston: 3.19.0
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)
@@ -3674,7 +3690,7 @@ packages:
       '@lov3kaizen/agentsea-core':
         optional: true
     dependencies:
-      '@lov3kaizen/agentsea-core': 1.0.1
+      '@lov3kaizen/agentsea-core': 1.0.1(ws@5.2.5)
       eventemitter3: 5.0.1
       lru-cache: 10.4.3
       nanoid: 5.1.6
@@ -4401,6 +4417,12 @@ packages:
   /@opentelemetry/semantic-conventions@1.41.1:
     resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
     engines: {node: '>=14'}
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@petamoriken/float16@3.9.3:
+    resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
     requiresBuild: true
     dev: false
     optional: true
@@ -5744,6 +5766,31 @@ packages:
     resolution: {integrity: sha512-jGTk8UD/RdjsNZW8qq10r0RBvxL8OWtoT+kImlzPDFilmozzM+9QmIJsmze9UiSBrFU45ZxhTYBypn9q9z/VfQ==}
     dev: true
 
+  /@shanghaikid/parquetjs@1.8.8:
+    resolution: {integrity: sha512-uaYXx4yP4cipVU8EZR4OZohiklsazyAcIXtfNEEYBcsMlnz5w4gEvv9vw+cP3yZBv7d1+OQYKfCfKI7oK0iUZQ==}
+    engines: {node: '>=18.18.2'}
+    requiresBuild: true
+    dependencies:
+      '@aws-sdk/client-s3': 3.948.0
+      '@types/node-int64': 0.4.32
+      '@types/thrift': 0.10.17
+      '@zenfs/core': 2.5.7
+      brotli-wasm: 3.0.1
+      bson: 6.10.4
+      int53: 1.0.0
+      long: 5.3.2
+      node-int64: 0.4.0
+      snappyjs: 0.7.0
+      thrift: 0.23.0
+      varint: 6.0.0
+      xxhash-wasm: 1.1.0
+    transitivePeerDependencies:
+      - aws-crt
+      - bufferutil
+      - utf-8-validate
+    dev: false
+    optional: true
+
   /@sinclair/typebox@0.29.6:
     resolution: {integrity: sha512-aX5IFYWlMa7tQ8xZr3b2gtVReCvg7f3LEhjir/JAjX2bJCMVJA5tIPv30wTD4KDfcwMd7DDYY3hFDeGmOgtrZQ==}
     requiresBuild: true
@@ -6588,6 +6635,14 @@ packages:
       murmurhash: 2.0.1
     dev: true
 
+  /@types/node-int64@0.4.32:
+    resolution: {integrity: sha512-xf/JsSlnXQ+mzvc0IpXemcrO4BrCfpgNpMco+GLcXkFk01k/gW9lGJu+Vof0ZSvHK6DsHJDPSbjFPs36QkWXqw==}
+    requiresBuild: true
+    dependencies:
+      '@types/node': 20.19.24
+    dev: false
+    optional: true
+
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
@@ -6602,6 +6657,14 @@ packages:
     dependencies:
       undici-types: 6.21.0
     dev: true
+
+  /@types/node@25.9.4:
+    resolution: {integrity: sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==}
+    requiresBuild: true
+    dependencies:
+      undici-types: 7.24.6
+    dev: false
+    optional: true
 
   /@types/pdf-parse@1.1.5:
     resolution: {integrity: sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==}
@@ -6619,6 +6682,12 @@ packages:
 
   /@types/prop-types@15.7.15:
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  /@types/q@1.5.8:
+    resolution: {integrity: sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@types/react-dom@18.3.7(@types/react@18.3.26):
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
@@ -6641,6 +6710,16 @@ packages:
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.5
     dev: false
+
+  /@types/thrift@0.10.17:
+    resolution: {integrity: sha512-bDX6d5a5ZDWC81tgDv224n/3PKNYfIQJTPHzlbk4vBWJrYXF6Tg1ncaVmP/c3JbGN2AK9p7zmHorJC2D6oejGQ==}
+    requiresBuild: true
+    dependencies:
+      '@types/node': 20.19.24
+      '@types/node-int64': 0.4.32
+      '@types/q': 1.5.8
+    dev: false
+    optional: true
 
   /@types/through@0.0.33:
     resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
@@ -7021,7 +7100,7 @@ packages:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 6.4.3(@types/node@20.19.24)
+      vite: 6.4.3(@types/node@22.19.3)
     dev: true
 
   /@vitest/pretty-format@3.2.6:
@@ -7060,10 +7139,32 @@ packages:
       tinyrainbow: 2.0.0
     dev: true
 
+  /@xenova/transformers@2.17.2:
+    resolution: {integrity: sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==}
+    requiresBuild: true
+    dependencies:
+      '@huggingface/jinja': 0.2.2
+      onnxruntime-web: 1.14.0
+      sharp: 0.32.6
+    optionalDependencies:
+      onnxruntime-node: 1.14.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+    dev: false
+    optional: true
+
   /@xmldom/xmldom@0.8.13:
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
     dev: false
+
+  /@xterm/xterm@5.5.0:
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@xyflow/react@12.9.2(@types/react@18.3.26)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-Xr+LFcysHCCoc5KRHaw+FwbqbWYxp9tWtk1mshNcqy25OAPuaKzXSdqIMNOA82TIXF/gFKo0Wgpa6PU7wUUVqw==}
@@ -7094,6 +7195,43 @@ packages:
       d3-selection: 3.0.0
       d3-zoom: 3.0.0
     dev: false
+
+  /@zenfs/core@2.5.7:
+    resolution: {integrity: sha512-g3C86mvi91Q2JuzGOwjG83tqEvZ0sl94wtw6AdUvEuRYocovFU3BwGrMobhg3ecvMQlVbqMJHaoA+jZgJ4duig==}
+    engines: {node: '>= 18'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@types/node': 25.9.4
+      buffer: 6.0.3
+      eventemitter3: 5.0.1
+      kerium: 1.3.9
+      memium: 0.4.5
+      readable-stream: 4.7.0
+      utilium: 3.4.0
+    dev: false
+    optional: true
+
+  /@zilliz/milvus2-sdk-node@2.6.17:
+    resolution: {integrity: sha512-Z+fCxhuHLV4kogU1T5SS9hDJqLH3KBEceU5snqDV/WDl6uxgNomqZY9md8TTRkHBISqNzDawEaZsi4MF6Y0oWA==}
+    requiresBuild: true
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.8.0
+      '@opentelemetry/api': 1.9.0
+      '@petamoriken/float16': 3.9.3
+      '@shanghaikid/parquetjs': 1.8.8
+      dayjs: 1.11.21
+      generic-pool: 3.9.0
+      lru-cache: 9.1.2
+      protobufjs: 7.6.3
+      winston: 3.19.0
+    transitivePeerDependencies:
+      - aws-crt
+      - bufferutil
+      - utf-8-validate
+    dev: false
+    optional: true
 
   /abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -7407,6 +7545,10 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /async-limiter@1.0.1:
+    resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
+    requiresBuild: true
+
   /async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
     dev: false
@@ -7674,6 +7816,19 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.1.1
+
+  /brotli-wasm@3.0.1:
+    resolution: {integrity: sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A==}
+    engines: {node: '>=v18.0.0'}
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /browser-or-node@1.3.0:
+    resolution: {integrity: sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /browserslist@4.27.0:
     resolution: {integrity: sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==}
@@ -8329,6 +8484,12 @@ packages:
   /dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
     dev: false
+
+  /dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /debounce-fn@4.0.0:
     resolution: {integrity: sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==}
@@ -9697,6 +9858,12 @@ packages:
       keyv: 4.5.4
     dev: true
 
+  /flatbuffers@1.12.0:
+    resolution: {integrity: sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
     dev: true
@@ -10101,6 +10268,12 @@ packages:
       - encoding
       - supports-color
     dev: false
+
+  /guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
@@ -10513,6 +10686,12 @@ packages:
       - '@types/node'
     dev: false
 
+  /int53@1.0.0:
+    resolution: {integrity: sha512-u8BMiMa05OPBgd32CKTead0CVTsFVgwFk23nNXo1teKPF6Sxcu0lXxEzP//zTcaKzXbGgPDXGmj/woyv+I4C5w==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -10862,6 +11041,16 @@ packages:
     dev: false
     optional: true
 
+  /isomorphic-ws@4.0.1(ws@5.2.5):
+    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
+    requiresBuild: true
+    peerDependencies:
+      ws: ^8.20.1
+    dependencies:
+      ws: 5.2.5
+    dev: false
+    optional: true
+
   /istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -11074,6 +11263,14 @@ packages:
     engines: {node: '>=12.0.0'}
     dev: false
 
+  /kerium@1.3.9:
+    resolution: {integrity: sha512-uoiTcutvUOjOpck8mmUUq7EsuNPhdfFoYMVehLmJGfdLmWC3nABU8KB63MQM0ydkAM4q+2zZmRIKovbx2LF8iA==}
+    requiresBuild: true
+    dependencies:
+      utilium: 3.4.0
+    dev: false
+    optional: true
+
   /keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
@@ -11239,6 +11436,12 @@ packages:
       triple-beam: 1.4.1
     dev: false
 
+  /long@4.0.0:
+    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
     requiresBuild: true
@@ -11285,6 +11488,13 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
     dev: false
+
+  /lru-cache@9.1.2:
+    resolution: {integrity: sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==}
+    engines: {node: 14 || >=16.14}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /lucide-react@0.356.0(react@18.3.1):
     resolution: {integrity: sha512-MDInjLrmZToccH2UxEshntujBlFwtOofGB22FN/eg39FfGVYV1TT1eMIv2j4rdaTJBpYjUuX7fEo9pwYkNFgwA==}
@@ -11544,6 +11754,15 @@ packages:
     dependencies:
       '@types/mdast': 4.0.4
     dev: false
+
+  /memium@0.4.5:
+    resolution: {integrity: sha512-mnmHWWlcyKnkKSSU0qL1Jsg+CsoikVZ2xsOatAN89R+j4V3m3WlQr0nUoqcjKDyUVF5ZGdNinRiZGVd+7A+TJQ==}
+    requiresBuild: true
+    dependencies:
+      kerium: 1.3.9
+      utilium: 3.4.0
+    dev: false
+    optional: true
 
   /memjs@1.3.2:
     resolution: {integrity: sha512-qUEg2g8vxPe+zPn09KidjIStHPtoBO8Cttm8bgJFWWabbsjQ9Av9Ky+6UcvKx6ue0LLb/LEhtcyQpRyKfzeXcg==}
@@ -12137,6 +12356,12 @@ packages:
     dependencies:
       semver: 7.7.3
 
+  /node-addon-api@6.1.0:
+    resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /node-ensure@0.0.0:
     resolution: {integrity: sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==}
     dev: false
@@ -12153,6 +12378,12 @@ packages:
       encoding: 0.1.13
       whatwg-url: 5.0.0
     dev: false
+
+  /node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -12296,7 +12527,43 @@ packages:
       mimic-function: 5.0.1
     dev: true
 
-  /openai@6.42.0(zod@3.25.76):
+  /onnx-proto@4.0.4:
+    resolution: {integrity: sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==}
+    requiresBuild: true
+    dependencies:
+      protobufjs: 6.11.6
+    dev: false
+    optional: true
+
+  /onnxruntime-common@1.14.0:
+    resolution: {integrity: sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /onnxruntime-node@1.14.0:
+    resolution: {integrity: sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==}
+    os: [win32, darwin, linux]
+    requiresBuild: true
+    dependencies:
+      onnxruntime-common: 1.14.0
+    dev: false
+    optional: true
+
+  /onnxruntime-web@1.14.0:
+    resolution: {integrity: sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==}
+    requiresBuild: true
+    dependencies:
+      flatbuffers: 1.12.0
+      guid-typescript: 1.0.9
+      long: 4.0.0
+      onnx-proto: 4.0.4
+      onnxruntime-common: 1.14.0
+      platform: 1.3.6
+    dev: false
+    optional: true
+
+  /openai@6.42.0(ws@5.2.5)(zod@3.25.76):
     resolution: {integrity: sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==}
     peerDependencies:
       ws: ^8.20.1
@@ -12307,6 +12574,7 @@ packages:
       zod:
         optional: true
     dependencies:
+      ws: 5.2.5
       zod: 3.25.76
 
   /opencollective-postinstall@2.0.3:
@@ -12750,6 +13018,12 @@ packages:
       find-up: 3.0.0
     dev: false
 
+  /platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /portfinder@1.0.38:
     resolution: {integrity: sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==}
     engines: {node: '>= 10.12'}
@@ -12953,6 +13227,27 @@ packages:
       protobufjs: 7.6.3
     dev: false
 
+  /protobufjs@6.11.6:
+    resolution: {integrity: sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/long': 4.0.2
+      '@types/node': 20.19.24
+      long: 4.0.0
+    dev: false
+    optional: true
+
   /protobufjs@7.6.3:
     resolution: {integrity: sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==}
     engines: {node: '>=12.0.0'}
@@ -13030,6 +13325,17 @@ packages:
       - supports-color
       - utf-8-validate
     dev: false
+
+  /q@1.5.1:
+    resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
+    engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
+    deprecated: |-
+      You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
+      (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
@@ -13628,6 +13934,26 @@ packages:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
     dev: false
 
+  /sharp@0.32.6:
+    resolution: {integrity: sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==}
+    engines: {node: '>=14.15.0'}
+    requiresBuild: true
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.1.2
+      node-addon-api: 6.1.0
+      prebuild-install: 7.1.3
+      semver: 7.7.3
+      simple-get: 4.0.1
+      tar-fs: 3.1.2
+      tunnel-agent: 0.6.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+    dev: false
+    optional: true
+
   /sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -13806,6 +14132,12 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
     dev: false
+
+  /snappyjs@0.7.0:
+    resolution: {integrity: sha512-u5iEEXkMe2EInQio6Wv9LWHOQYRDbD2O9hzS27GpT/lwfIQhTCnHCTqedqHIHe9ZcvQo+9au6vngQayipz1NYw==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /socket.io-adapter@2.5.5:
     resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
@@ -14479,6 +14811,23 @@ packages:
       real-require: 0.2.0
     dev: false
 
+  /thrift@0.23.0:
+    resolution: {integrity: sha512-j7F1ls8JogClU88Ta/pwD/OzYuiFeD6Z5GoWw7ip+jcDhcNYFKgfXYEsyLXYpiNfJO94fbLnITGxyfZ19YzA6Q==}
+    engines: {node: '>= 10.18.0'}
+    requiresBuild: true
+    dependencies:
+      browser-or-node: 1.3.0
+      isomorphic-ws: 4.0.1(ws@5.2.5)
+      node-int64: 0.4.0
+      q: 1.5.1
+      uuid: 14.0.0
+      ws: 5.2.5
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+    optional: true
+
   /through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: false
@@ -14855,6 +15204,12 @@ packages:
   /undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  /undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /undici@6.26.0:
     resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
     engines: {node: '>=18.17'}
@@ -15025,6 +15380,18 @@ packages:
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  /utilium@3.4.0:
+    resolution: {integrity: sha512-z4PavqKX0P4XB9SKtXRWWBCDyoDxV6vmTEH4WDBN1/lrYf6MDVk+gntCY6YbryOKjBHGIsYHOS6BTzHf5cF9vQ==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      '@xterm/xterm': 5.5.0
+    dev: false
+    optional: true
+
   /uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
@@ -15034,6 +15401,12 @@ packages:
     resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
     engines: {node: '>= 0.10'}
     dev: false
+
+  /varint@6.0.0:
+    resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -15586,6 +15959,20 @@ packages:
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  /ws@5.2.5:
+    resolution: {integrity: sha512-G0gACQIjFmv7NqpaOAXEpe9nEtRYD6ZCy2Ip/B4EzR08qEwnf/wYJoQd3cjosPdnJsHkeh0j2tzOaIBZIOC1yA==}
+    requiresBuild: true
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dependencies:
+      async-limiter: 1.0.1
+
   /ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
@@ -15622,6 +16009,12 @@ packages:
   /xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
+
+  /xxhash-wasm@1.1.0:
+    resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}


### PR DESCRIPTION
Stack PR 5/6. Stacked on #37.

Closes the **Embeddings** Beta gap (Weaviate/Milvus/pgvector + local ONNX were advertised in types but unimplemented).

## Vector stores
- **PgVectorStore** — PostgreSQL + pgvector via `pg` (lazy/optional). Auto-creates the extension/table, upserts with `ON CONFLICT`, ANN search with the metric-appropriate operator (`<=>` / `<->` / `<#>`), JSONB metadata filtering, quoted identifiers. Accepts an injected pool for DI/testing.
- **WeaviateStore** + **MilvusStore** — store logic talks to a small high-level backend interface; the brittle SDK calls are isolated in thin `*SdkBackend` adapters (`weaviate-ts-client`, `@zilliz/milvus2-sdk-node`). Translation logic is fully unit-tested via injected mock backends.
- `createStore()` now constructs all three instead of throwing.

## Local ONNX
- `LocalProvider` `modelPath` now loads an ONNX feature-extraction model via **Transformers.js** (`@xenova/transformers`, optional) with mean pooling — was previously `not implemented`.

New SDKs are optional deps loaded via `importOptional()`, so the package type-checks/builds without them installed.

## Tests
- embeddings: 370 passed (new `vector-stores.test.ts`; updated `create-store` / `local-provider`)
- type-check / lint / build clean
- README: Embeddings graduated 🧪 Beta → ✅ Stable

> Note: real-service behavior (live Postgres/Weaviate/Milvus, ONNX model downloads) is covered by the injected-boundary unit tests here; end-to-end runs against live infra are intended as guarded integration tests.