### PR TITLE
fix(crews,memory,embeddings,evaluate): ship types, bundle nanoid, add crew concurrency

### DIFF
--- a/.changeset/crews-types-bundle-concurrency.md
+++ b/.changeset/crews-types-bundle-concurrency.md
@@ -1,0 +1,58 @@
+---
+'@lov3kaizen/agentsea-crews': minor
+'@lov3kaizen/agentsea-embeddings': patch
+'@lov3kaizen/agentsea-evaluate': patch
+'@lov3kaizen/agentsea-memory': patch
+---
+
+Ship type declarations, bundle the ESM-only `nanoid`, and add opt-in task
+concurrency.
+
+**crews**
+
+- **Fix: ship type declarations.** The build emitted no `.d.ts`, so `1.1.0`
+  published with `types`/`exports` (including the `./nestjs` / `./templates`
+  subpaths) pointing at declaration files that never existed — TypeScript
+  consumers had to add an ambient shim. The build now runs from a
+  `tsup.config.ts` with `dts: true` and emits declarations for every entry point.
+- **Feat: concurrent task execution.** `kickoff()` / `kickoffStream()` accept a
+  `maxConcurrentTasks` option, and `CrewConfig.maxConcurrentTasks` is now wired
+  in. Ready tasks within a scheduling iteration run through a bounded worker pool
+  (default `1` — fully sequential, unchanged behavior). A per-call value
+  overrides the config; a task failure stops new launches, drains in-flight work,
+  and surfaces the same fatal `crew:error` as the sequential path.
+
+**crews, embeddings, evaluate, memory — bundle nanoid**
+
+These packages emit a CJS build that previously externalized `nanoid@5`
+(ESM-only), producing a runtime `require('nanoid')` that throws on Node
+<20.19 / <22.12 (unflagged `require(ESM)`). `nanoid` is now bundled into the
+output (`noExternal`), so the CJS build no longer requires it at runtime and
+works on any supported Node. `nanoid` moved from `dependencies` to
+`devDependencies` accordingly.
+
+**memory — fix broken `exports` map**
+
+`memory` declared `"type": "module"`, which flips tsup's output extensions
+(esm→`.js`, cjs→`.cjs`), but its `exports`/`main`/`module` were written for the
+CommonJS convention (esm→`.mjs`, cjs→`.js`). The result: the `import` condition
+pointed at `.mjs` files that were never emitted, and the `require` condition
+resolved to an ESM `.js` file — so both `require()` and `import` of the package
+could fail. Removing the stray `"type": "module"` realigns the build output with
+the existing `exports` map (CJS `require` → `./dist/index.js`, ESM `import` →
+`./dist/index.mjs`), both verified to load.
+
+**memory — fix importance scoring returning Promises**
+
+The synchronous importance helpers in `utils/importance` (`calculateImportanceWithRecency`,
+`calculateImportanceWithAccess`, `calculateImportanceWithContext`,
+`calculateCombinedImportance`, `createImportanceCalculator`, `filterByImportance`,
+`sortByImportance`) wrapped their results in `Promise.resolve(...)` despite being
+typed (and documented) as returning plain values. Besides breaking the public
+type contract, `calculateCombinedImportance` multiplied those Promises
+arithmetically and returned `NaN`. The wrappers are removed so the functions
+return real numbers/arrays; added regression tests covering all of them.
+
+(The other nanoid-using packages — analytics, cache, costs, debugger, ingest,
+prompts, redteam, structured — are ESM-only and `import` nanoid as ESM, so they
+were never affected and are unchanged.)

--- a/packages/crews/README.md
+++ b/packages/crews/README.md
@@ -180,6 +180,36 @@ const crew = createCrew({
 });
 ```
 
+### Concurrency
+
+By default a crew runs ready tasks **sequentially**, which keeps event ordering
+deterministic. For independent tasks you can opt into a bounded worker pool so
+they execute in parallel — set it on the crew config or per `kickoff()` call:
+
+```typescript
+// Crew-wide default
+const crew = new Crew({
+  name: 'Research Crew',
+  agents: [...],
+  delegationStrategy: 'best-match',
+  maxConcurrentTasks: 4, // up to 4 ready tasks run at once
+});
+
+// Or override per run (takes precedence over the config value)
+const result = await crew.kickoff({ maxConcurrentTasks: 4 });
+```
+
+Notes:
+
+- The default is `1` (fully sequential) — behavior is unchanged unless you opt in.
+- Only tasks that are _ready_ in the same scheduling iteration run together, so
+  dependency ordering is still respected.
+- With concurrency `> 1`, `task:assigned` / `task:completed` events from
+  different tasks interleave as workers settle (each task still emits its own
+  events in order). If a task fails after exhausting retries, no further tasks
+  are launched, in-flight tasks are allowed to settle, and the crew ends with the
+  same fatal `crew:error` as the sequential path.
+
 ### Memory Systems
 
 Share state and knowledge across agents:

--- a/packages/crews/package.json
+++ b/packages/crews/package.json
@@ -27,8 +27,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/nestjs/index.ts src/templates/index.ts --format cjs,esm --clean --external reflect-metadata --external @nestjs/common --external @nestjs/core",
-    "dev": "tsup src/index.ts src/nestjs/index.ts src/templates/index.ts --format cjs,esm --dts --watch --external reflect-metadata --external @nestjs/common --external @nestjs/core",
+    "build": "tsup",
+    "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:cov": "vitest run --coverage",
@@ -36,12 +36,12 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "eventemitter3": "^5.0.0",
-    "nanoid": "^5.0.0"
+    "eventemitter3": "^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
     "@vitest/coverage-v8": "^3.2.6",
+    "nanoid": "^5.0.0",
     "tsup": "^8.0.1",
     "typescript": "^5.3.3",
     "vitest": "^3.2.6"

--- a/packages/crews/src/__tests__/crew.test.ts
+++ b/packages/crews/src/__tests__/crew.test.ts
@@ -603,4 +603,136 @@ describe('Crew', () => {
       expect(crew.getStatus().state).toBe('aborted');
     });
   });
+
+  describe('concurrent task execution', () => {
+    // Builds a crew whose single agent records how many task executions run at
+    // the same time, so tests can assert sequential vs. parallel scheduling.
+    function createTrackingCrew(
+      taskCount: number,
+      crewOverrides: Partial<CrewConfig> = {},
+    ): { crew: Crew; tracker: { maxActive: number; completed: number } } {
+      const tracker = { active: 0, maxActive: 0, completed: 0 };
+
+      const agent = new CrewAgent({
+        config: createMockAgentConfig({ name: 'Worker' }),
+        execute: async () => {
+          tracker.active += 1;
+          tracker.maxActive = Math.max(tracker.maxActive, tracker.active);
+          await new Promise((resolve) => setTimeout(resolve, 40));
+          tracker.active -= 1;
+          tracker.completed += 1;
+          return {
+            output: 'done',
+            tokensUsed: 10,
+            latencyMs: 40,
+            iterations: 1,
+          };
+        },
+      });
+
+      const crew = new Crew({
+        ...createMockCrewConfig(),
+        agents: [],
+        ...crewOverrides,
+      });
+      crew.addAgent(agent);
+
+      // Independent tasks (no dependencies) so all are ready simultaneously.
+      for (let i = 0; i < taskCount; i += 1) {
+        crew.addTask({
+          description: `Task ${i + 1}`,
+          expectedOutput: 'Output',
+          requiredCapabilities: ['coding'],
+        });
+      }
+
+      return { crew, tracker };
+    }
+
+    it('runs tasks sequentially by default (maxActive === 1)', async () => {
+      const { crew, tracker } = createTrackingCrew(4);
+
+      const result = await crew.kickoff();
+
+      expect(result.success).toBe(true);
+      expect(tracker.completed).toBe(4);
+      expect(tracker.maxActive).toBe(1);
+    });
+
+    it('runs tasks concurrently when maxConcurrentTasks > 1 is passed to kickoff', async () => {
+      const { crew, tracker } = createTrackingCrew(4);
+
+      const result = await crew.kickoff({ maxConcurrentTasks: 4 });
+
+      expect(result.success).toBe(true);
+      expect(tracker.completed).toBe(4);
+      expect(tracker.maxActive).toBeGreaterThan(1);
+    });
+
+    it('honors the maxConcurrentTasks crew config', async () => {
+      const { crew, tracker } = createTrackingCrew(4, {
+        maxConcurrentTasks: 2,
+      });
+
+      const result = await crew.kickoff();
+
+      expect(result.success).toBe(true);
+      expect(tracker.completed).toBe(4);
+      expect(tracker.maxActive).toBe(2);
+    });
+
+    it('lets a per-call maxConcurrentTasks override the crew config', async () => {
+      const { crew, tracker } = createTrackingCrew(4, {
+        maxConcurrentTasks: 1,
+      });
+
+      const result = await crew.kickoff({ maxConcurrentTasks: 4 });
+
+      expect(result.success).toBe(true);
+      expect(tracker.maxActive).toBeGreaterThan(1);
+    });
+
+    it('still emits assigned + completed events for every task when concurrent', async () => {
+      const { crew } = createTrackingCrew(3);
+
+      const events: string[] = [];
+      for await (const event of crew.kickoffStream({ maxConcurrentTasks: 3 })) {
+        events.push(event.type);
+      }
+
+      expect(events.filter((t) => t === 'task:assigned')).toHaveLength(3);
+      expect(events.filter((t) => t === 'task:completed')).toHaveLength(3);
+    });
+
+    it('surfaces a task failure as a fatal crew error in concurrent mode', async () => {
+      const failingAgent = new CrewAgent({
+        config: createMockAgentConfig({ name: 'Flaky' }),
+        execute: async () => {
+          throw new Error('boom');
+        },
+      });
+
+      const crew = new Crew({
+        ...createMockCrewConfig(),
+        agents: [],
+      });
+      crew.addAgent(failingAgent);
+      crew.addTask({
+        description: 'Doomed task',
+        expectedOutput: 'Output',
+        requiredCapabilities: ['coding'],
+      });
+      crew.addTask({
+        description: 'Another doomed task',
+        expectedOutput: 'Output',
+        requiredCapabilities: ['coding'],
+      });
+
+      const result = await crew.kickoff({ maxConcurrentTasks: 2 });
+
+      expect(result.success).toBe(false);
+      expect(crew.getStatus().state).toBe('failed');
+      expect(result.events.some((e) => e.type === 'crew:error')).toBe(true);
+    });
+  });
 });

--- a/packages/crews/src/core/Crew.ts
+++ b/packages/crews/src/core/Crew.ts
@@ -48,6 +48,13 @@ export interface CrewExecutionOptions {
   delegationStrategy?: DelegationStrategyType;
   /** Timeout for the entire execution (ms) */
   timeoutMs?: number;
+  /**
+   * Maximum number of ready tasks to execute concurrently within a single
+   * scheduling iteration. Defaults to the crew's `maxConcurrentTasks` config,
+   * or `1` (fully sequential) when neither is set. Values `> 1` run independent
+   * tasks in parallel, trading deterministic event ordering for lower latency.
+   */
+  maxConcurrentTasks?: number;
   /** Enable verbose logging */
   verbose?: boolean;
 }
@@ -282,39 +289,55 @@ export class Crew {
           continue;
         }
 
-        // Process tasks
-        for (const task of readyTasks) {
-          // Check if still running
-          if (this.state !== 'running') break;
+        // Process ready tasks. Sequential by default to preserve deterministic
+        // event ordering; concurrent when opted in via options.maxConcurrentTasks
+        // or the crew's maxConcurrentTasks config.
+        const concurrency = Math.max(
+          1,
+          options.maxConcurrentTasks ?? this.config.maxConcurrentTasks ?? 1,
+        );
 
-          // Delegate task
-          const delegationResult = await this.delegateTask(task, options);
+        if (concurrency === 1) {
+          for (const task of readyTasks) {
+            // Check if still running
+            if (this.state !== 'running') break;
 
-          // Yield delegation event
-          yield this.createEvent<TaskAssignedEvent>({
-            type: 'task:assigned',
-            taskId: task.id,
-            agentName: delegationResult.selectedAgent,
-            reason: delegationResult.reason,
-            strategy: this.config.delegationStrategy,
-          });
+            // Delegate task
+            const delegationResult = await this.delegateTask(task, options);
 
-          // Execute task
-          const taskResult = await this.executeTask(task, delegationResult);
+            // Yield delegation event
+            yield this.createEvent<TaskAssignedEvent>({
+              type: 'task:assigned',
+              taskId: task.id,
+              agentName: delegationResult.selectedAgent,
+              reason: delegationResult.reason,
+              strategy: this.config.delegationStrategy,
+            });
 
-          // Yield task result events
-          yield this.createEvent<TaskCompletedEvent>({
-            type: 'task:completed',
-            taskId: task.id,
-            result: taskResult,
-            agentName: delegationResult.selectedAgent,
-            durationMs: taskResult.latencyMs ?? 0,
-          });
+            // Execute task
+            const taskResult = await this.executeTask(task, delegationResult);
 
-          // Yield any queued events
-          while (eventQueue.length > 0) {
-            yield eventQueue.shift()!;
+            // Yield task result events
+            yield this.createEvent<TaskCompletedEvent>({
+              type: 'task:completed',
+              taskId: task.id,
+              result: taskResult,
+              agentName: delegationResult.selectedAgent,
+              durationMs: taskResult.latencyMs ?? 0,
+            });
+
+            // Yield any queued events
+            while (eventQueue.length > 0) {
+              yield eventQueue.shift()!;
+            }
           }
+        } else {
+          yield* this.processReadyTasksConcurrently(
+            readyTasks,
+            options,
+            eventQueue,
+            concurrency,
+          );
         }
 
         // Handle paused state (state can change asynchronously via abort/pause)
@@ -365,6 +388,107 @@ export class Crew {
       results: Array.from(this.results.values()),
     });
     this.addTimelineEntry('crew_completed', this.name);
+  }
+
+  /**
+   * Execute a batch of ready tasks concurrently with a bounded worker pool.
+   *
+   * Each task still emits its `task:assigned` and `task:completed` events in
+   * order relative to itself, but events across tasks are interleaved as the
+   * workers settle. At most `concurrency` tasks run at once. If any task throws
+   * (after exhausting retries), no further tasks are started, in-flight tasks
+   * are allowed to settle, and the first error is rethrown so the caller's
+   * error handling (crew:error) behaves identically to the sequential path.
+   */
+  private async *processReadyTasksConcurrently(
+    readyTasks: Task[],
+    options: CrewExecutionOptions,
+    eventQueue: CrewEvent[],
+    concurrency: number,
+  ): AsyncGenerator<CrewEvent> {
+    let nextIndex = 0;
+    let firstError: unknown;
+    const buffer: CrewEvent[] = [];
+    const inFlight = new Set<Promise<void>>();
+
+    const launch = (task: Task): void => {
+      const worker: Promise<void> = (async () => {
+        const delegationResult = await this.delegateTask(task, options);
+
+        buffer.push(
+          this.createEvent<TaskAssignedEvent>({
+            type: 'task:assigned',
+            taskId: task.id,
+            agentName: delegationResult.selectedAgent,
+            reason: delegationResult.reason,
+            strategy: this.config.delegationStrategy,
+          }),
+        );
+
+        const taskResult = await this.executeTask(task, delegationResult);
+
+        buffer.push(
+          this.createEvent<TaskCompletedEvent>({
+            type: 'task:completed',
+            taskId: task.id,
+            result: taskResult,
+            agentName: delegationResult.selectedAgent,
+            durationMs: taskResult.latencyMs ?? 0,
+          }),
+        );
+      })()
+        .catch((error: unknown) => {
+          // Preserve the first failure; mirror sequential behaviour where the
+          // throw propagates out and is surfaced as a fatal crew:error.
+          if (firstError === undefined) {
+            firstError = error;
+          }
+        })
+        .finally(() => {
+          inFlight.delete(worker);
+        });
+
+      inFlight.add(worker);
+    };
+
+    const fill = (): void => {
+      while (
+        inFlight.size < concurrency &&
+        nextIndex < readyTasks.length &&
+        this.state === 'running' &&
+        firstError === undefined
+      ) {
+        launch(readyTasks[nextIndex++]);
+      }
+    };
+
+    fill();
+
+    while (inFlight.size > 0) {
+      await Promise.race(inFlight);
+
+      // Drain task-lifecycle events first, then any context-emitted events.
+      while (buffer.length > 0) {
+        yield buffer.shift()!;
+      }
+      while (eventQueue.length > 0) {
+        yield eventQueue.shift()!;
+      }
+
+      fill();
+    }
+
+    // Final drain in case the last settled worker queued trailing events.
+    while (buffer.length > 0) {
+      yield buffer.shift()!;
+    }
+    while (eventQueue.length > 0) {
+      yield eventQueue.shift()!;
+    }
+
+    if (firstError !== undefined) {
+      throw firstError;
+    }
   }
 
   /**

--- a/packages/crews/src/types/crew.types.ts
+++ b/packages/crews/src/types/crew.types.ts
@@ -357,8 +357,22 @@ export interface CrewExecutionOptions {
   input?: string;
   /** Override delegation strategy */
   strategy?: DelegationStrategyType;
+  /**
+   * Override delegation strategy (alias of {@link CrewExecutionOptions.strategy}
+   * used internally by the executor). Either field is honored.
+   */
+  delegationStrategy?: DelegationStrategyType;
+  /** Additional context values seeded into the execution context */
+  context?: Record<string, unknown>;
   /** Timeout override */
   timeoutMs?: number;
+  /**
+   * Maximum number of ready tasks to execute concurrently within a single
+   * scheduling iteration. Defaults to the crew's `maxConcurrentTasks` config,
+   * or `1` (fully sequential) when neither is set. Values `> 1` run independent
+   * tasks in parallel, trading deterministic event ordering for lower latency.
+   */
+  maxConcurrentTasks?: number;
   /** Whether to stream events */
   stream?: boolean;
   /** Checkpoint to resume from */

--- a/packages/crews/tsup.config.ts
+++ b/packages/crews/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/nestjs/index.ts', 'src/templates/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  external: ['reflect-metadata', '@nestjs/common', '@nestjs/core'],
+  // nanoid@5 is ESM-only. Bundling it inlines the implementation so the CJS
+  // build never emits a runtime `require('nanoid')` — which would otherwise
+  // fail on Node <20.19 / <22.12 (unflagged require(ESM)).
+  noExternal: ['nanoid'],
+});

--- a/packages/embeddings/package.json
+++ b/packages/embeddings/package.json
@@ -37,8 +37,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/chunking/index.ts src/caching/index.ts src/stores/index.ts src/providers/index.ts --format cjs,esm --dts --clean --external ioredis --external better-sqlite3 --external chromadb --external @pinecone-database/pinecone --external @qdrant/js-client-rest --external weaviate-ts-client --external cohere-ai --external ollama --external pg --external @zilliz/milvus2-sdk-node --external @xenova/transformers",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "tsup",
+    "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -70,12 +70,12 @@
   },
   "dependencies": {
     "eventemitter3": "^5.0.0",
-    "lru-cache": "^10.0.0",
-    "nanoid": "^5.0.0"
+    "lru-cache": "^10.0.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
     "@types/node": "^20.0.0",
+    "nanoid": "^5.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.3.0",
     "vitest": "^3.2.6"

--- a/packages/embeddings/tsup.config.ts
+++ b/packages/embeddings/tsup.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: [
+    'src/index.ts',
+    'src/chunking/index.ts',
+    'src/caching/index.ts',
+    'src/stores/index.ts',
+    'src/providers/index.ts',
+  ],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  external: [
+    'ioredis',
+    'better-sqlite3',
+    'chromadb',
+    '@pinecone-database/pinecone',
+    '@qdrant/js-client-rest',
+    'weaviate-ts-client',
+    'cohere-ai',
+    'ollama',
+    'pg',
+    '@zilliz/milvus2-sdk-node',
+    '@xenova/transformers',
+  ],
+  // nanoid@5 is ESM-only. Bundling it inlines the implementation so the CJS
+  // build never emits a runtime `require('nanoid')` — which would otherwise
+  // fail on Node <20.19 / <22.12 (unflagged require(ESM)).
+  noExternal: ['nanoid'],
+});

--- a/packages/evaluate/package.json
+++ b/packages/evaluate/package.json
@@ -42,8 +42,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/feedback/index.ts src/evaluation/index.ts src/datasets/index.ts src/annotation/index.ts src/continuous/index.ts --format cjs,esm --dts --clean --external better-sqlite3 --external @huggingface/hub --external nodemailer",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "build": "tsup",
+    "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -74,12 +74,12 @@
   },
   "dependencies": {
     "eventemitter3": "^5.0.0",
-    "nanoid": "^5.0.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
     "@types/node": "^20.0.0",
+    "nanoid": "^5.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.3.0",
     "vitest": "^3.2.6"

--- a/packages/evaluate/tsup.config.ts
+++ b/packages/evaluate/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: [
+    'src/index.ts',
+    'src/feedback/index.ts',
+    'src/evaluation/index.ts',
+    'src/datasets/index.ts',
+    'src/annotation/index.ts',
+    'src/continuous/index.ts',
+  ],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  external: ['better-sqlite3', '@huggingface/hub', 'nodemailer'],
+  // nanoid@5 is ESM-only. Bundling it inlines the implementation so the CJS
+  // build never emits a runtime `require('nanoid')` — which would otherwise
+  // fail on Node <20.19 / <22.12 (unflagged require(ESM)).
+  noExternal: ['nanoid'],
+});

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -5,7 +5,6 @@
     "node": ">=20.0.0"
   },
   "description": "Advanced memory management system for AI agents with semantic retrieval, hierarchical structures, and multi-agent support",
-  "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -86,7 +85,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/stores/index.ts src/retrieval/index.ts src/structures/index.ts src/processing/index.ts src/sharing/index.ts src/debug/index.ts --format cjs,esm --dts --clean --external better-sqlite3 --external pg --external ioredis --external @pinecone-database/pinecone",
+    "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
@@ -96,7 +95,6 @@
   },
   "dependencies": {
     "eventemitter3": "^5.0.0",
-    "nanoid": "^5.0.0",
     "lru-cache": "^10.0.0"
   },
   "peerDependencies": {
@@ -121,6 +119,7 @@
     "@types/better-sqlite3": "^7.6.8",
     "@types/node": "^20.10.0",
     "@types/pg": "^8.10.0",
+    "nanoid": "^5.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.3.0",
     "vitest": "^3.2.6"

--- a/packages/memory/src/__tests__/importance.test.ts
+++ b/packages/memory/src/__tests__/importance.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateImportanceWithRecency,
+  calculateImportanceWithAccess,
+  calculateImportanceWithContext,
+  calculateCombinedImportance,
+  createImportanceCalculator,
+  categorizeImportance,
+  filterByImportance,
+  sortByImportance,
+} from '../utils/importance.js';
+import type { MemoryEntry } from '../types/index.js';
+
+function makeEntry(overrides: Partial<MemoryEntry> = {}): MemoryEntry {
+  const now = Date.now();
+  return {
+    id: 'mem-1',
+    content: 'A reasonably sized memory entry used for scoring.',
+    type: 'fact',
+    importance: 0.6,
+    metadata: { source: 'explicit', confidence: 0.9 },
+    timestamp: now,
+    accessCount: 0,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe('importance scoring utilities', () => {
+  // These helpers are declared synchronous (`: number` / `: MemoryEntry[]`).
+  // They previously wrapped results in Promise.resolve(), which both broke the
+  // public type contract and caused calculateCombinedImportance to multiply
+  // Promises arithmetically (producing NaN). These tests lock in the fix.
+
+  it('calculateImportanceWithRecency returns a plain number in [0, 1]', () => {
+    const score = calculateImportanceWithRecency(makeEntry());
+    expect(typeof score).toBe('number');
+    expect(score).not.toBeNaN();
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(1);
+  });
+
+  it('recency score decays for older memories', () => {
+    const halfLife = 7 * 24 * 60 * 60 * 1000;
+    const fresh = calculateImportanceWithRecency(
+      makeEntry({ timestamp: Date.now() }),
+      halfLife,
+    );
+    const old = calculateImportanceWithRecency(
+      makeEntry({ timestamp: Date.now() - 30 * 24 * 60 * 60 * 1000 }),
+      halfLife,
+    );
+    expect(fresh).toBeGreaterThan(old);
+  });
+
+  it('calculateImportanceWithAccess returns a plain number and boosts with access', () => {
+    const none = calculateImportanceWithAccess(makeEntry({ accessCount: 0 }));
+    const many = calculateImportanceWithAccess(makeEntry({ accessCount: 10 }));
+    expect(typeof many).toBe('number');
+    expect(many).toBeGreaterThan(none);
+    expect(many).toBeLessThanOrEqual(1);
+  });
+
+  it('calculateImportanceWithContext returns a plain number and boosts on match', () => {
+    const base = makeEntry({
+      importance: 0.5,
+      metadata: { source: 'explicit', confidence: 0.9, userId: 'u1' },
+    });
+    const matched = calculateImportanceWithContext(base, { userId: 'u1' });
+    const unmatched = calculateImportanceWithContext(base, { userId: 'other' });
+    expect(typeof matched).toBe('number');
+    expect(matched).toBeGreaterThan(unmatched);
+  });
+
+  it('calculateCombinedImportance returns a finite number (regression: not NaN)', () => {
+    const score = calculateCombinedImportance(makeEntry(), {
+      context: { userId: 'u1' },
+    });
+    expect(typeof score).toBe('number');
+    expect(Number.isFinite(score)).toBe(true);
+    expect(score).not.toBeNaN();
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(1);
+  });
+
+  it('createImportanceCalculator produces a synchronous numeric scorer', () => {
+    const calc = createImportanceCalculator({ confidenceWeight: 0.5 });
+    const score = calc('some memory content here', 'preference', {
+      source: 'explicit',
+      confidence: 0.8,
+    });
+    expect(typeof score).toBe('number');
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(1);
+  });
+
+  it('categorizeImportance buckets scores', () => {
+    expect(categorizeImportance(0.95)).toBe('critical');
+    expect(categorizeImportance(0.75)).toBe('high');
+    expect(categorizeImportance(0.55)).toBe('medium');
+    expect(categorizeImportance(0.35)).toBe('low');
+    expect(categorizeImportance(0.1)).toBe('trivial');
+  });
+
+  it('filterByImportance returns an array (not a Promise)', () => {
+    const memories = [
+      makeEntry({ id: 'a', importance: 0.2 }),
+      makeEntry({ id: 'b', importance: 0.8 }),
+    ];
+    const result = filterByImportance(memories, 0.5);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('b');
+  });
+
+  it('sortByImportance returns a sorted array (not a Promise)', () => {
+    const memories = [
+      makeEntry({ id: 'a', importance: 0.2 }),
+      makeEntry({ id: 'b', importance: 0.9 }),
+      makeEntry({ id: 'c', importance: 0.5 }),
+    ];
+    const desc = sortByImportance(memories);
+    expect(Array.isArray(desc)).toBe(true);
+    expect(desc.map((m) => m.id)).toEqual(['b', 'c', 'a']);
+
+    const asc = sortByImportance(memories, false);
+    expect(asc.map((m) => m.id)).toEqual(['a', 'c', 'b']);
+  });
+});

--- a/packages/memory/src/utils/importance.ts
+++ b/packages/memory/src/utils/importance.ts
@@ -37,7 +37,7 @@ export function calculateImportanceWithRecency(
   const recencyFactor = Math.exp(-age / halfLifeMs);
   const recencyBoost = 0.5 + 0.5 * recencyFactor;
 
-  return Promise.resolve(Math.min(memory.importance * recencyBoost, 1));
+  return Math.min(memory.importance * recencyBoost, 1);
 }
 
 /**
@@ -50,7 +50,7 @@ export function calculateImportanceWithAccess(
   const accessFactor = Math.min(memory.accessCount / 10, 1);
   const accessBoost = 1 + accessFactor * maxAccessBoost;
 
-  return Promise.resolve(Math.min(memory.importance * accessBoost, 1));
+  return Math.min(memory.importance * accessBoost, 1);
 }
 
 /**
@@ -79,7 +79,7 @@ export function calculateImportanceWithContext(
     contextMultiplier *= 1.3;
   }
 
-  return Promise.resolve(Math.min(memory.importance * contextMultiplier, 1));
+  return Math.min(memory.importance * contextMultiplier, 1);
 }
 
 /**
@@ -130,12 +130,10 @@ export function calculateCombinedImportance(
     accessScore * weights.access +
     contextScore * weights.context;
 
-  return Promise.resolve(
-    Math.min(
-      combined /
-        (weights.base + weights.recency + weights.access + weights.context),
-      1,
-    ),
+  return Math.min(
+    combined /
+      (weights.base + weights.recency + weights.access + weights.context),
+    1,
   );
 }
 
@@ -183,7 +181,7 @@ export function createImportanceCalculator(options: {
       importance *= 0.9;
     }
 
-    return Promise.resolve(Math.min(Math.max(importance, 0), 1));
+    return Math.min(Math.max(importance, 0), 1);
   };
 }
 
@@ -207,7 +205,7 @@ export function filterByImportance(
   memories: MemoryEntry[],
   threshold: number,
 ): MemoryEntry[] {
-  return Promise.resolve(memories.filter((m) => m.importance >= threshold));
+  return memories.filter((m) => m.importance >= threshold);
 }
 
 /**
@@ -218,5 +216,5 @@ export function sortByImportance(
   descending: boolean = true,
 ): MemoryEntry[] {
   const sorted = [...memories].sort((a, b) => a.importance - b.importance);
-  return Promise.resolve(descending ? sorted.reverse() : sorted);
+  return descending ? sorted.reverse() : sorted;
 }

--- a/packages/memory/tsup.config.ts
+++ b/packages/memory/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: [
+    'src/index.ts',
+    'src/stores/index.ts',
+    'src/retrieval/index.ts',
+    'src/structures/index.ts',
+    'src/processing/index.ts',
+    'src/sharing/index.ts',
+    'src/debug/index.ts',
+  ],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  external: ['better-sqlite3', 'pg', 'ioredis', '@pinecone-database/pinecone'],
+  // nanoid@5 is ESM-only. Bundling it inlines the implementation so the CJS
+  // build never emits a runtime `require('nanoid')` — which would otherwise
+  // fail on Node <20.19 / <22.12 (unflagged require(ESM)).
+  noExternal: ['nanoid'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,10 +282,10 @@ importers:
     dependencies:
       '@lov3kaizen/agentsea-core':
         specifier: '>=0.6.0'
-        version: 1.0.1(ws@5.2.5)
+        version: link:../core
       '@lov3kaizen/agentsea-embeddings':
         specifier: '>=1.0.0'
-        version: 1.0.1(@lov3kaizen/agentsea-core@1.0.1)(graphql@16.12.0)(typescript@5.9.3)
+        version: link:../embeddings
       eventemitter3:
         specifier: ^5.0.1
         version: 5.0.1
@@ -390,7 +390,7 @@ importers:
         version: 12.0.2
       openai:
         specifier: ^6.42.0
-        version: 6.42.0(ws@5.2.5)(zod@3.25.76)
+        version: 6.42.0(zod@3.25.76)
       winston:
         specifier: ^3.19.0
         version: 3.19.0
@@ -492,9 +492,6 @@ importers:
       eventemitter3:
         specifier: ^5.0.0
         version: 5.0.1
-      nanoid:
-        specifier: ^5.0.0
-        version: 5.1.6
     devDependencies:
       '@types/node':
         specifier: ^20.11.0
@@ -502,6 +499,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.6
         version: 3.2.6(vitest@3.2.6)
+      nanoid:
+        specifier: ^5.0.0
+        version: 5.1.6
       tsup:
         specifier: ^8.0.1
         version: 8.5.0(typescript@5.9.3)
@@ -516,7 +516,7 @@ importers:
     dependencies:
       '@lov3kaizen/agentsea-core':
         specifier: '>=0.6.0'
-        version: 1.0.1(ws@5.2.5)
+        version: link:../core
       deep-diff:
         specifier: ^1.0.2
         version: 1.0.2
@@ -569,16 +569,13 @@ importers:
     dependencies:
       '@lov3kaizen/agentsea-core':
         specifier: '>=0.6.0'
-        version: 1.0.1(ws@5.2.5)
+        version: link:../core
       eventemitter3:
         specifier: ^5.0.0
         version: 5.0.1
       lru-cache:
         specifier: ^10.0.0
         version: 10.4.3
-      nanoid:
-        specifier: ^5.0.0
-        version: 5.1.6
     optionalDependencies:
       '@pinecone-database/pinecone':
         specifier: ^2.0.0
@@ -614,6 +611,9 @@ importers:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.24
+      nanoid:
+        specifier: ^5.0.0
+        version: 5.1.6
       tsup:
         specifier: ^8.0.0
         version: 8.5.0(typescript@5.9.3)
@@ -628,13 +628,10 @@ importers:
     dependencies:
       '@lov3kaizen/agentsea-core':
         specifier: '>=0.6.0'
-        version: 1.0.1(ws@5.2.5)
+        version: link:../core
       eventemitter3:
         specifier: ^5.0.0
         version: 5.0.1
-      nanoid:
-        specifier: ^5.0.0
-        version: 5.1.6
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -655,6 +652,9 @@ importers:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.24
+      nanoid:
+        specifier: ^5.0.0
+        version: 5.1.6
       tsup:
         specifier: ^8.0.0
         version: 8.5.0(typescript@5.9.3)
@@ -672,7 +672,7 @@ importers:
         version: 1.19.14(hono@4.12.25)
       '@lov3kaizen/agentsea-core':
         specifier: '>=0.6.0'
-        version: 1.0.1(ws@5.2.5)
+        version: link:../core
       hono:
         specifier: ^4.12.21
         version: 4.12.25
@@ -837,19 +837,16 @@ importers:
     dependencies:
       '@lov3kaizen/agentsea-core':
         specifier: '>=0.6.0'
-        version: 1.0.1(ws@5.2.5)
+        version: link:../core
       '@lov3kaizen/agentsea-embeddings':
         specifier: '>=1.0.0'
-        version: 1.0.1(@lov3kaizen/agentsea-core@1.0.1)(graphql@16.12.0)(typescript@5.9.3)
+        version: link:../embeddings
       eventemitter3:
         specifier: ^5.0.0
         version: 5.0.1
       lru-cache:
         specifier: ^10.0.0
         version: 10.4.3
-      nanoid:
-        specifier: ^5.0.0
-        version: 5.1.6
     optionalDependencies:
       '@pinecone-database/pinecone':
         specifier: ^2.0.0
@@ -873,6 +870,9 @@ importers:
       '@types/pg':
         specifier: ^8.10.0
         version: 8.16.0
+      nanoid:
+        specifier: ^5.0.0
+        version: 5.1.6
       tsup:
         specifier: ^8.0.0
         version: 8.5.0(typescript@5.9.3)
@@ -1050,7 +1050,7 @@ importers:
     dependencies:
       '@lov3kaizen/agentsea-core':
         specifier: '>=0.6.0'
-        version: 1.0.1(ws@5.2.5)
+        version: link:../core
       cron-parser:
         specifier: ^5.0.4
         version: 5.6.1
@@ -1107,7 +1107,7 @@ importers:
         version: 9.39.2
       openai:
         specifier: ^6.42.0
-        version: 6.42.0(ws@5.2.5)(zod@3.25.76)
+        version: 6.42.0(zod@3.25.76)
       tsup:
         specifier: ^8.3.5
         version: 8.5.0(typescript@5.9.3)
@@ -3663,64 +3663,6 @@ packages:
   /@js-sdsl/ordered-map@4.4.2:
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
     requiresBuild: true
-    dev: false
-
-  /@lov3kaizen/agentsea-core@1.0.1(ws@5.2.5):
-    resolution: {integrity: sha512-BHRgff/ef9i/fVlUmDVujJCpSA6lfAUe2xqPUScR3OITWznKpqVEgPze/q3Psq2EdtYxtBrcmxpy6KK/lsoW1w==}
-    engines: {node: '>=20.0.0'}
-    dependencies:
-      '@anthropic-ai/sdk': 0.104.1(zod@3.25.76)
-      '@google/generative-ai': 0.24.1
-      '@lov3kaizen/agentsea-types': 1.0.1
-      fast-glob: 3.3.3
-      ioredis: 5.11.1
-      marked: 12.0.2
-      openai: 6.42.0(ws@5.2.5)(zod@3.25.76)
-      winston: 3.19.0
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-      - ws
-    dev: false
-
-  /@lov3kaizen/agentsea-embeddings@1.0.1(@lov3kaizen/agentsea-core@1.0.1)(graphql@16.12.0)(typescript@5.9.3):
-    resolution: {integrity: sha512-PI6prrQeymA2NeLsHzF9CrHHQC2acc99/vIZeBEVkaPTbe/VmV82x37w3Y1cXzSH19gkgI0M1yBxfxPJ07Go7Q==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@lov3kaizen/agentsea-core': '>=0.6.0'
-    peerDependenciesMeta:
-      '@lov3kaizen/agentsea-core':
-        optional: true
-    dependencies:
-      '@lov3kaizen/agentsea-core': 1.0.1(ws@5.2.5)
-      eventemitter3: 5.0.1
-      lru-cache: 10.4.3
-      nanoid: 5.1.6
-    optionalDependencies:
-      '@pinecone-database/pinecone': 2.2.2
-      '@qdrant/js-client-rest': 1.16.2(typescript@5.9.3)
-      better-sqlite3: 11.10.0
-      chromadb: 1.10.5
-      ioredis: 5.11.1
-      weaviate-ts-client: 2.2.0(graphql@16.12.0)
-    transitivePeerDependencies:
-      - '@google/generative-ai'
-      - cohere-ai
-      - encoding
-      - graphql
-      - ollama
-      - openai
-      - supports-color
-      - typescript
-      - voyageai
-    dev: false
-
-  /@lov3kaizen/agentsea-types@1.0.1:
-    resolution: {integrity: sha512-qeHmAYbKu8NujFLuqlpewkBNMwUN4BRBYXZkC/QUqkO6rC0y6UExaTtZcqgsg8/A5Y6hAK8rXboTnVz8nL41wg==}
-    engines: {node: '>=20.0.0'}
-    dependencies:
-      zod: 3.25.76
     dev: false
 
   /@lukeed/csprng@1.1.0:
@@ -7103,7 +7045,7 @@ packages:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 6.4.3(@types/node@22.19.3)
+      vite: 6.4.3(@types/node@20.19.24)
     dev: true
 
   /@vitest/pretty-format@3.2.6:
@@ -7551,6 +7493,8 @@ packages:
   /async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
     requiresBuild: true
+    dev: false
+    optional: true
 
   /async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -7636,6 +7580,7 @@ packages:
 
   /bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    requiresBuild: true
     peerDependencies:
       bare-abort-controller: '*'
     peerDependenciesMeta:
@@ -12258,7 +12203,6 @@ packages:
     resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
     engines: {node: ^18 || >=20}
     hasBin: true
-    dev: false
 
   /napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
@@ -12574,7 +12518,7 @@ packages:
     dev: false
     optional: true
 
-  /openai@6.42.0(ws@5.2.5)(zod@3.25.76):
+  /openai@6.42.0(zod@3.25.76):
     resolution: {integrity: sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==}
     peerDependencies:
       ws: ^8.20.1
@@ -12585,7 +12529,6 @@ packages:
       zod:
         optional: true
     dependencies:
-      ws: 5.2.5
       zod: 3.25.76
 
   /opencollective-postinstall@2.0.3:
@@ -15999,6 +15942,8 @@ packages:
         optional: true
     dependencies:
       async-limiter: 1.0.1
+    dev: false
+    optional: true
 
   /ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}


### PR DESCRIPTION
## Summary

Packaging and correctness fixes across the CJS-emitting packages, plus an opt-in concurrency feature for `crews`. A changeset is included so this is ready to version & publish (`crews` minor; `embeddings` / `evaluate` / `memory` patch).

## crews
- **Ship type declarations.** The build emitted no `.d.ts`, so `1.1.0` published with `types`/`exports` (incl. `./nestjs` and `./templates`) pointing at declaration files that never existed — consumers had to add an ambient shim. Build now runs from `tsup.config.ts` with `dts: true`; declarations are emitted for every entry point.
- **Add concurrent task execution.** `kickoff()` / `kickoffStream()` accept `maxConcurrentTasks`, and `CrewConfig.maxConcurrentTasks` is now wired in. Ready tasks run through a bounded worker pool (**default `1` = fully sequential, unchanged behavior**). A per-call value overrides the config; a task failure stops new launches, drains in-flight work, and surfaces the same fatal `crew:error` as the sequential path.

## crews, embeddings, evaluate, memory — bundle nanoid
These packages emit a CJS build that previously externalized `nanoid@5` (ESM-only), producing a runtime `require('nanoid')` that throws on Node `<20.19` / `<22.12` (unflagged `require(ESM)`). `nanoid` is now bundled (`noExternal`), so the CJS build no longer requires it at runtime and works on any supported Node. `nanoid` moved from `dependencies` to `devDependencies`.

## memory
- **Fix broken `exports` map.** `memory` declared `"type": "module"`, which flips tsup's output extensions (esm→`.js`, cjs→`.cjs`), but its `exports`/`main`/`module` were written for the CommonJS convention (esm→`.mjs`, cjs→`.js`). The `import` condition pointed at `.mjs` files that were never emitted and `require` resolved to an ESM `.js` — so both `require()` and `import` of the package could fail. Removing the stray `"type": "module"` realigns output with the map (both verified to load).
- **Fix importance scoring returning Promises.** The synchronous helpers in `utils/importance` wrapped results in `Promise.resolve(...)` despite being typed as returning plain values. Besides breaking the type contract, `calculateCombinedImportance` multiplied those Promises arithmetically and returned `NaN`. Wrappers removed; added regression tests covering all of them.

> The other nanoid-using packages (analytics, cache, costs, debugger, ingest, prompts, redteam, structured) are ESM-only and `import` nanoid as ESM, so they were never affected and are unchanged.

## Testing
- `crews` 468 ✅ · `embeddings` 370 ✅ · `evaluate` 270 ✅ · `memory` 302 ✅ (incl. 6 new concurrency tests + 9 new importance tests)
- `memory` typecheck now clean (was failing on `main`)
- All four packages build (cjs/esm/dts); CJS bundles verified to `require()` with nanoid inlined and all `exports` targets resolve on disk