### PR TITLE
docs: refresh README + guides to latest models; explore Nango/Composio integrations

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -29,7 +29,7 @@ import {
 const agent = new Agent(
   {
     name: 'assistant',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-opus-4-8',
     provider: 'anthropic',
     systemPrompt: 'You are a helpful assistant.',
   },
@@ -94,7 +94,7 @@ import { readFileSync, writeFileSync } from 'fs';
 const agent = new Agent(
   {
     name: 'voice-assistant',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-opus-4-8',
     provider: 'anthropic',
     systemPrompt: 'You are a helpful voice assistant.',
   },
@@ -135,7 +135,7 @@ writeFileSync('./response.mp3', result.audio!);
 sea code
 
 # Use a specific model
-sea code --provider anthropic --model claude-sonnet-4-20250514
+sea code --provider anthropic --model claude-opus-4-8
 
 # Verbose mode (shows tool calls, token usage, latency)
 sea code --verbose
@@ -167,7 +167,7 @@ agentsea code
 # Create an agent
 agentsea agent create my-agent \
   --provider anthropic \
-  --model claude-sonnet-4-20250514
+  --model claude-opus-4-8
 
 # Run agent with a message
 agentsea agent run my-agent "What is the capital of France?"
@@ -216,7 +216,7 @@ async function bootstrap() {
     {
       name: 'customer-support',
       description: 'AI customer support agent',
-      model: 'claude-3-5-sonnet-20241022',
+      model: 'claude-opus-4-8',
       provider: 'anthropic',
     },
     new AnthropicProvider(),
@@ -357,7 +357,7 @@ import { calculatorTool, weatherTool } from '@lov3kaizen/agentsea-core';
 const agent = new Agent(
   {
     name: 'assistant',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-opus-4-8',
     provider: 'anthropic',
     tools: [calculatorTool, weatherTool],
   },

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ AgentSea ships a typed model registry (60+ models with capabilities and live pri
 | Provider             | Latest models                                                                                                                  | Notes                                               |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
 | **Anthropic Claude** | `claude-opus-4-8` _(default)_, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-fable-5` | Adaptive thinking on Opus 4.6+, Sonnet 4.6, Fable 5 |
-| **OpenAI**           | `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.1` (+ `codex` variants), `gpt-5`, `gpt-4.1`, `o1`                                             | Reasoning-effort aware, per-model capability typing |
-| **Google Gemini**    | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.0-flash`                                                                       |                                                     |
+| **OpenAI**           | `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.2` (+ `pro` / `codex`), `gpt-5.1`, `o3`, `o1`                                                | Reasoning-effort aware, per-model capability typing |
+| **Google Gemini**    | `gemini-3.5-flash`, `gemini-3.1-pro-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`                                             |                                                     |
 | **Local / OSS**      | Ollama, LM Studio, LocalAI, vLLM, Text Generation WebUI, any OpenAI-compatible endpoint                                        | Run fully on your own hardware                      |
 
-Older generations (Claude 3.x / Sonnet 4.5, GPT-4o, Gemini 1.5, …) remain supported. See [`@lov3kaizen/agentsea-types`](./packages/types) for the full registry and [costs](./packages/costs) for the pricing table.
+Older generations (Claude 3.x / Sonnet 4.5, GPT-4o, Gemini 1.5/2.0, …) remain supported. See [`@lov3kaizen/agentsea-types`](./packages/types) for the full registry and [costs](./packages/costs) for the pricing table.
 
 ## 🚀 Quick Start
 
@@ -126,7 +126,7 @@ const geminiAgent = new Agent(
 
 // Use OpenAI
 const openaiAgent = new Agent(
-  { model: 'gpt-5.1', provider: 'openai' },
+  { model: 'gpt-5.5', provider: 'openai' },
   new OpenAIProvider(process.env.OPENAI_API_KEY),
   toolRegistry,
 );

--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ AgentSea ADK unites AI agents and services to create powerful, intelligent appli
 - 🚀 **Production Ready** - Rate limiting, caching, error handling, retries
 - 📘 **TypeScript** - Fully typed with comprehensive definitions
 
+## 🧠 Supported Models
+
+AgentSea ships a typed model registry (60+ models with capabilities and live pricing). Latest highlights per provider — pass any of these as `model`:
+
+| Provider             | Latest models                                                                                                                  | Notes                                               |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
+| **Anthropic Claude** | `claude-opus-4-8` _(default)_, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-fable-5` | Adaptive thinking on Opus 4.6+, Sonnet 4.6, Fable 5 |
+| **OpenAI**           | `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.1` (+ `codex` variants), `gpt-5`, `gpt-4.1`, `o1`                                             | Reasoning-effort aware, per-model capability typing |
+| **Google Gemini**    | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.0-flash`                                                                       |                                                     |
+| **Local / OSS**      | Ollama, LM Studio, LocalAI, vLLM, Text Generation WebUI, any OpenAI-compatible endpoint                                        | Run fully on your own hardware                      |
+
+Older generations (Claude 3.x / Sonnet 4.5, GPT-4o, Gemini 1.5, …) remain supported. See [`@lov3kaizen/agentsea-types`](./packages/types) for the full registry and [costs](./packages/costs) for the pricing table.
+
 ## 🚀 Quick Start
 
 ### Requirements
@@ -71,7 +84,7 @@ import {
 const agent = new Agent(
   {
     name: 'assistant',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-opus-4-8',
     provider: 'anthropic',
     systemPrompt: 'You are a helpful assistant.',
     tools: [calculatorTool],
@@ -106,21 +119,21 @@ import {
 
 // Use Gemini
 const geminiAgent = new Agent(
-  { model: 'gemini-pro', provider: 'gemini' },
+  { model: 'gemini-2.5-pro', provider: 'gemini' },
   new GeminiProvider(process.env.GEMINI_API_KEY),
   toolRegistry,
 );
 
 // Use OpenAI
 const openaiAgent = new Agent(
-  { model: 'gpt-4-turbo-preview', provider: 'openai' },
+  { model: 'gpt-5.1', provider: 'openai' },
   new OpenAIProvider(process.env.OPENAI_API_KEY),
   toolRegistry,
 );
 
 // Use Anthropic
 const claudeAgent = new Agent(
-  { model: 'claude-sonnet-4-20250514', provider: 'anthropic' },
+  { model: 'claude-opus-4-8', provider: 'anthropic' },
   new AnthropicProvider(process.env.ANTHROPIC_API_KEY),
   toolRegistry,
 );
@@ -154,12 +167,19 @@ Get compile-time validation for model-specific options. Inspired by [TanStack AI
 ```typescript
 import { anthropic, openai, createProvider } from '@lov3kaizen/agentsea-core';
 
-// ✅ Valid: Claude 3.5 Sonnet supports tools, system prompts, and extended thinking
-const claudeConfig = anthropic('claude-3-5-sonnet-20241022', {
+// ✅ Valid: Claude Opus 4.8 supports tools and system prompts. Thinking is
+// adaptive on 4.6+ models, so budget_tokens-style config is intentionally
+// not part of the type.
+const claudeConfig = anthropic('claude-opus-4-8', {
+  tools: [myTool],
+  systemPrompt: 'You are a helpful assistant',
+});
+
+// ✅ Valid: Claude Sonnet 4.5 still exposes explicit extended thinking
+const sonnetConfig = anthropic('claude-sonnet-4-5-20250929', {
   tools: [myTool],
   systemPrompt: 'You are a helpful assistant',
   thinking: { type: 'enabled', budgetTokens: 10000 },
-  temperature: 0.7,
 });
 
 // ✅ Valid: o1 supports tools but NOT system prompts
@@ -167,12 +187,6 @@ const o1Config = openai('o1', {
   tools: [myTool],
   reasoningEffort: 'high',
   // systemPrompt: '...' // ❌ TypeScript error - o1 doesn't support system prompts
-});
-
-// ❌ TypeScript error: o1-mini doesn't support tools
-const o1MiniConfig = openai('o1-mini', {
-  // tools: [myTool], // Error: 'tools' does not exist in type
-  reasoningEffort: 'medium',
 });
 
 // Create type-safe providers
@@ -258,7 +272,7 @@ const toolRegistry = new ToolRegistry();
 const agent = new Agent(
   {
     name: 'voice-assistant',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-opus-4-8',
     provider: 'anthropic',
     systemPrompt: 'You are a helpful voice assistant.',
     description: 'Voice assistant',
@@ -336,7 +350,7 @@ const acpTools = createACPTools(acpClient);
 const shoppingAgent = new Agent(
   {
     name: 'shopping-assistant',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-opus-4-8',
     provider: 'anthropic',
     systemPrompt: 'You are a helpful shopping assistant.',
     tools: acpTools, // Includes 14 commerce tools
@@ -400,7 +414,7 @@ Launch an interactive AI coding session with 13 built-in tools:
 sea code
 
 # Use a specific provider/model
-sea code --provider anthropic --model claude-sonnet-4-20250514
+sea code --provider anthropic --model claude-opus-4-8
 
 # Verbose mode with token usage and latency
 sea code --verbose
@@ -456,7 +470,7 @@ import { AnthropicProvider } from '@lov3kaizen/agentsea-core';
     AgenticModule.forRoot({
       provider: new AnthropicProvider(),
       defaultConfig: {
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-opus-4-8',
         provider: 'anthropic',
       },
       enableRestApi: true, // Enable REST API endpoints
@@ -545,7 +559,7 @@ AgentSea follows a clean, layered architecture:
 └─────────────────────────────────────────┘
                     │
 ┌─────────────────────────────────────────┐
-│         AgentSea ADK Layer               │
+│         AgentSea ADK Layer              │
 │  ┌─────────────────────────────────┐    │
 │  │  Multi-Agent Orchestration      │    │
 │  └─────────────────────────────────┘    │
@@ -570,63 +584,21 @@ AgentSea follows a clean, layered architecture:
 └─────────────────────────────────────────┘
 ```
 
-## 🎯 Core Concepts
+## Core Concepts
 
-### Agents
-
-Autonomous AI entities that can reason, use tools, and maintain conversation context.
-
-### Crews
-
-Multi-agent teams with defined roles, delegation strategies, and coordinated task execution.
-
-### Tools
-
-Functions that agents can call to perform specific tasks (API calls, calculations, etc.).
-
-### Memory
-
-Hierarchical memory system with episodic, semantic, and working memory structures. Supports multi-agent sharing with access control.
-
-### Guardrails
-
-Input validation, output filtering, and safety checks to ensure responsible AI behavior.
-
-### Evaluation
-
-LLM-as-Judge, human feedback collection, and continuous monitoring for quality assurance.
-
-### Gateway
-
-OpenAI-compatible API gateway with intelligent routing, load balancing, and fallback handling.
-
-### MCP
-
-Model Context Protocol integration for seamless tool and resource integration.
-
-### Conversation Schemas
-
-Define structured conversation flows with validation and dynamic routing.
-
-### Agentic Coding
-
-Interactive AI coding sessions with 13 built-in tools for file operations, code editing, search, shell execution, and git operations. Works with any provider.
-
-### Red Teaming
-
-Proactive security testing with adversarial attack generation, vulnerability scanning, jailbreak detection, compliance checking, and audit logging.
-
-### Prompt Management
-
-Git-like version control for prompts with environment promotion (dev/staging/prod), A/B testing, and team collaboration.
-
-### Debugger
-
-Step-through agent execution with breakpoints, checkpoint replay, what-if scenario testing, and decision tree visualization.
-
-### Analytics
-
-Conversation analytics with intent classification, sentiment analysis, topic clustering, anomaly detection, and KPI tracking.
+| Concept                   | What it is                                                                                           |
+| ------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **Agents**                | Autonomous entities that reason, call tools, and keep conversation context                           |
+| **Crews**                 | Multi-agent teams with roles, delegation, and sequential/concurrent task execution                   |
+| **Tools**                 | Functions agents call (built-in coding/general tools, MCP tools, or your own)                        |
+| **Memory**                | Episodic, semantic, and working memory with multi-agent sharing and access control                   |
+| **Guardrails**            | Input validation, output filtering, prompt-injection/PII safety checks                               |
+| **Gateway**               | OpenAI-compatible gateway with routing, load balancing, caching, and fallbacks                       |
+| **MCP**                   | Model Context Protocol for plug-in tools and resources                                               |
+| **Conversation Schemas**  | Structured, validated conversation flows with dynamic routing                                        |
+| **Evaluation / Red Team** | LLM-as-Judge, human feedback, monitoring + adversarial attack generation and jailbreak detection     |
+| **Prompts / Debugger**    | Git-like prompt versioning & A/B testing; step-through execution with checkpoints and what-if replay |
+| **Analytics**             | Intent classification, sentiment, topic clustering, anomaly detection, and KPI tracking              |
 
 ## 📚 Documentation
 
@@ -704,73 +676,6 @@ pnpm lint
 pnpm type-check
 ```
 
-## ✅ Feature Status
-
-Maturity is tracked per area. **Stable** = implemented and covered by tests;
-**Beta** = usable and tested but with known gaps or rough edges (see each package
-README); **WIP** = under active development, APIs and behavior may change.
-
-### ✅ Stable
-
-- [x] Multi-provider support (Claude, GPT, Gemini) with 60+ models including GPT-5, GPT-4.1, o3, o4-mini
-- [x] Per-model type safety with compile-time validation of model-specific options
-- [x] Local & open source model support (Ollama, LM Studio, LocalAI, etc.)
-- [x] Voice support (TTS/STT) with multiple providers
-- [x] Command-line interface (CLI) with interactive chat
-- [x] Agentic coding (`sea code`) with 13 built-in coding tools
-- [x] MCP protocol integration
-- [x] ACP (Agentic Commerce Protocol) with 14 commerce operations
-- [x] Conversation schema system with step-based flows
-- [x] Advanced memory stores (Buffer, Redis, PostgreSQL, SQLite, Pinecone)
-- [x] Memory structures (Episodic, Semantic, Working)
-- [x] Multi-agent memory sharing with access control
-- [x] LLM Gateway with OpenAI-compatible API, caching, and cost optimization
-- [x] Intelligent routing (round-robin, least-latency, cost-based)
-- [x] Structured output with Zod schema enforcement
-- [x] Document ingestion pipeline with parsers and chunkers
-- [x] Guardrails for content safety, prompt injection, and PII detection
-- [x] Content filtering and validation
-- [x] Intelligent caching with semantic similarity, streaming replay, and multi-tier support
-- [x] Prompt management with version control, A/B testing, and environment promotion
-- [x] Agent debugger with step-through execution, checkpoint replay, and what-if testing
-- [x] Conversation analytics with intent classification, sentiment, and topic clustering
-- [x] Built-in tools (13 coding tools + 8 general tools + custom support)
-- [x] Observability (logging, metrics, tracing)
-- [x] Cost tracking with 60+ model pricing registry and budget enforcement
-- [x] NestJS integration for all packages
-- [x] React components for agent interfaces
-- [x] Multi-tenancy support
-- [x] Rate limiting and caching
-- [x] TypeScript definitions with strict type safety
-- [x] CI/CD workflows with automated releases
-- [x] **Crews** — multi-agent orchestration (role-based coordination; round-robin,
-      best-match, auction, hierarchical, and consensus delegation) with real LLM
-      execution by default via the core-backed `CoreExecutor` (mock path opt-in
-      with `mock: true`). The default execution path is covered end-to-end in the
-      `e2e` package via an injectable provider seam.
-- [x] **Evaluate** — LLM evaluation metrics, LLM-as-Judge, human feedback, and
-      preference learning (RLHF/DPO). Continuous monitoring with email (SMTP via
-      nodemailer), webhook/Slack, and PagerDuty (Events API v2) alert channels;
-      HuggingFace dataset import (datasets-server REST) and Hub export
-      (`@huggingface/hub`).
-- [x] **Red Team** — adversarial attack generation, vulnerability scanning, and
-      jailbreak detection; safety benchmarks, compliance checking. Continuous
-      testing with cron-driven schedules (`cron-parser`), real alert delivery
-      (webhook/Slack/Teams/Discord/PagerDuty/email), and tamper-evident,
-      hash-chained audit logging with pluggable persistent storage
-      (`FileAuditStore`).
-- [x] **Embeddings** — multi-provider support (OpenAI, Cohere, Voyage, HuggingFace),
-      chunking, caching, and Pinecone/Chroma/Qdrant/**pgvector/Weaviate/Milvus**
-      stores, plus local **ONNX** models via Transformers.js
-      (`@xenova/transformers`).
-- [x] **Surf** — vision-driven computer use and browser automation across
-      **Puppeteer/Playwright** (chromium/firefox/webkit), **Docker**,
-      **Kubernetes** (pod via `kubectl exec`), **VNC/RDP** (remote display), and
-      native Linux/macOS/Windows backends. Backend action translation is
-      unit-tested (injected exec/clients) and a guarded headless smoke test
-      covers the real browser launch path. VNC/RDP frame-capture and the RDP
-      transport are experimental — inject a custom client for production.
-
 ### 🚧 Work in Progress
 
 - [ ] Admin UI dashboard improvements
@@ -796,8 +701,6 @@ Built with ❤️ by [lovekaizen](https://lovekaizen.com)
 Special thanks to:
 
 - [Anthropic](https://anthropic.com) for Claude
-- [OpenAI](https://openai.com) for GPT
-- [Google](https://ai.google.dev) for Gemini
 - The open source community
 
 ---

--- a/docs/ACP_INTEGRATION.md
+++ b/docs/ACP_INTEGRATION.md
@@ -46,7 +46,7 @@ const acpTools = createACPTools(acpClient);
 const agent = new Agent(
   {
     name: 'shopping-assistant',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-opus-4-8',
     provider: 'anthropic',
     tools: acpTools,
     systemPrompt: 'You are a helpful shopping assistant...',

--- a/docs/API.md
+++ b/docs/API.md
@@ -50,7 +50,7 @@ GET /agents
     {
       "name": "customer-support",
       "description": "AI customer support agent",
-      "model": "claude-3-5-sonnet-20241022",
+      "model": "claude-opus-4-8",
       "provider": "anthropic",
       "tools": ["search", "order-lookup"]
     }
@@ -76,7 +76,7 @@ GET /agents/:name
   "data": {
     "name": "customer-support",
     "description": "AI customer support agent",
-    "model": "claude-3-5-sonnet-20241022",
+    "model": "claude-opus-4-8",
     "provider": "anthropic",
     "systemPrompt": "You are a helpful customer support agent...",
     "tools": [

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -412,7 +412,7 @@ sea config
     "default": {
       "name": "default",
       "description": "Default agent",
-      "model": "claude-sonnet-4-20250514",
+      "model": "claude-opus-4-8",
       "provider": "anthropic",
       "systemPrompt": "You are a helpful assistant.",
       "temperature": 0.7,
@@ -487,7 +487,7 @@ sea init
 # 3. Create production agent
 sea agent create
 # Name: prod
-# Model: claude-sonnet-4-20250514
+# Model: claude-opus-4-8
 # High quality settings
 
 # 4. Run tasks

--- a/docs/FORMATTING.md
+++ b/docs/FORMATTING.md
@@ -30,7 +30,7 @@ const agent = new Agent(
   {
     name: 'my-agent',
     description: 'Agent with formatting',
-    model: 'claude-3-5-sonnet-20241022',
+    model: 'claude-opus-4-8',
     provider: 'anthropic',
     outputFormat: 'markdown', // or 'text', 'html', 'react'
     formatOptions: {
@@ -386,7 +386,7 @@ import { AgentDecorator } from '@lov3kaizen/agentsea-nestjs';
 @AgentDecorator({
   name: 'my-agent',
   description: 'Agent with formatting',
-  model: 'claude-3-5-sonnet-20241022',
+  model: 'claude-opus-4-8',
   provider: 'anthropic',
   outputFormat: 'html',
   formatOptions: {

--- a/docs/PER_MODEL_TYPE_SAFETY.md
+++ b/docs/PER_MODEL_TYPE_SAFETY.md
@@ -123,12 +123,10 @@ const o3MiniConfig = openai('o3-mini', {
 
 **Typed models (latest first):**
 
-- `gpt-5.2` (+ `pro`/`codex`), `gpt-5.1` (+ `codex` variants)
+- `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.2` (+ `pro`/`codex`), `gpt-5.1` (+ `codex` variants)
 - `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-pro`, `gpt-4.1`
 - `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`, `gpt-4`, `gpt-3.5-turbo`
 - Reasoning: `o3`, `o3-pro`, `o3-mini`, `o1`, `o1-mini`
-
-> Even newer models (e.g. `gpt-5.5`, `gpt-5.4-mini`) are accepted at runtime via the plain string `model` field and priced in the [costs](../packages/costs) registry; they're added to the typed builder above as the type registry catches up.
 
 ### `gemini(model, config?)`
 
@@ -154,10 +152,9 @@ const geminiConfig = gemini('gemini-1.5-pro', {
 
 **Typed models (latest first):**
 
+- `gemini-3.5-flash`, `gemini-3.1-pro-preview`
 - `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.0-flash`
 - `gemini-1.5-pro`, `gemini-1.5-flash`, `gemini-1.5-flash-8b`
-
-> Newer Gemini releases (e.g. `gemini-3.5-flash`, `gemini-3.1-pro-preview`) are accepted at runtime via the string `model` field and priced in the [costs](../packages/costs) registry, ahead of the typed builder.
 
 ### `ollama(model, config?)`
 
@@ -266,7 +263,7 @@ console.log(`Context window: ${info?.capabilities.contextWindow}`);
 
 ## Model Capability Reference
 
-> The tables below are illustrative. The latest typed models — Claude Opus 4.6–4.8, Sonnet 4.6, Fable 5; GPT-5.1/5.2 and o3; Gemini 2.5 — are in the registry; call `getModelInfo(model)` for exact, up-to-date capabilities, context window, and max output.
+> The tables below are illustrative. The latest typed models — Claude Opus 4.6–4.8, Sonnet 4.6, Fable 5; GPT-5.5/5.4-mini/5.2 and o3; Gemini 3.5/3.1/2.5 — are in the registry; call `getModelInfo(model)` for exact, up-to-date capabilities, context window, and max output.
 
 ### Anthropic Models
 

--- a/docs/PER_MODEL_TYPE_SAFETY.md
+++ b/docs/PER_MODEL_TYPE_SAFETY.md
@@ -29,7 +29,7 @@ import {
 } from '@lov3kaizen/agentsea-core';
 
 // Type-safe configuration for Claude
-const claudeConfig = anthropic('claude-3-5-sonnet-20241022', {
+const claudeConfig = anthropic('claude-opus-4-8', {
   tools: [myTool],
   systemPrompt: 'You are helpful',
   temperature: 0.7,
@@ -48,35 +48,41 @@ AgentSea provides config builder functions for each provider:
 ```typescript
 import { anthropic } from '@lov3kaizen/agentsea-core';
 
-// Claude 3.5 Sonnet - supports everything
-const config = anthropic('claude-3-5-sonnet-20241022', {
+// Claude Opus 4.8 (recommended default) - tools + system prompts.
+// Thinking is adaptive on 4.6+ models, so budget_tokens-style config is not
+// part of the type for them.
+const config = anthropic('claude-opus-4-8', {
   tools: [myTool],
   systemPrompt: 'You are a helpful assistant',
-  thinking: { type: 'enabled', budgetTokens: 10000 }, // Extended thinking
   temperature: 0.7,
   maxTokens: 4096,
   providerOptions: {
     metadata: { userId: 'user-123' },
-    betas: ['computer-use-2024-10-22'],
   },
 });
 
-// Claude 3 Haiku - NO extended thinking
-const haikuConfig = anthropic('claude-3-haiku-20240307', {
+// Claude Sonnet 4.5 - still exposes explicit extended thinking
+const thinkingConfig = anthropic('claude-sonnet-4-5-20250929', {
+  tools: [myTool],
+  systemPrompt: 'You are a helpful assistant',
+  thinking: { type: 'enabled', budgetTokens: 10000 },
+});
+
+// Claude Haiku 4.5 - fast/cheap, NO extended thinking
+const haikuConfig = anthropic('claude-haiku-4-5-20251001', {
   tools: [myTool],
   systemPrompt: 'You are fast',
   // thinking: { ... } // ❌ TypeScript error!
 });
 ```
 
-**Supported Models:**
+**Supported Models (latest first):**
 
-- `claude-3-5-sonnet-20241022`, `claude-3-5-sonnet-latest`
-- `claude-3-5-haiku-20241022`, `claude-3-5-haiku-latest`
-- `claude-3-opus-20240229`, `claude-3-opus-latest`
-- `claude-3-sonnet-20240229`, `claude-3-haiku-20240307`
+- `claude-opus-4-8` _(default)_, `claude-opus-4-7`, `claude-opus-4-6`
+- `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-fable-5`
+- `claude-sonnet-4-5-20250929`, `claude-opus-4-5-20251101`
 - `claude-opus-4-0-20250514`, `claude-sonnet-4-0-20250514`
-- `claude-opus-4-5-20251101`
+- Claude 3.x family (`claude-3-5-sonnet-*`, `claude-3-5-haiku-*`, `claude-3-opus-*`, …)
 
 ### `openai(model, config?)`
 
@@ -115,15 +121,12 @@ const o3MiniConfig = openai('o3-mini', {
 });
 ```
 
-**Supported Models:**
+**Supported Models (latest first):**
 
-- `gpt-4o`, `gpt-4o-2024-11-20`, `gpt-4o-2024-08-06`
-- `gpt-4o-mini`, `gpt-4o-mini-2024-07-18`
-- `gpt-4-turbo`, `gpt-4-turbo-2024-04-09`, `gpt-4-turbo-preview`
-- `gpt-4`, `gpt-4-0613`
-- `gpt-3.5-turbo`, `gpt-3.5-turbo-0125`
-- `o1`, `o1-2024-12-17`, `o1-mini`, `o1-mini-2024-09-12`, `o1-preview`
-- `o3-mini`, `o3-mini-2025-01-31`
+- `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.2` (+ `pro`/`codex`), `gpt-5.1` (+ `codex` variants)
+- `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-pro`, `gpt-4.1`
+- `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`, `gpt-4`, `gpt-3.5-turbo`
+- Reasoning: `o3`, `o3-pro`, `o3-mini`, `o1`, `o1-mini`
 
 ### `gemini(model, config?)`
 
@@ -147,12 +150,11 @@ const geminiConfig = gemini('gemini-1.5-pro', {
 });
 ```
 
-**Supported Models:**
+**Supported Models (latest first):**
 
-- `gemini-2.0-flash-exp`, `gemini-2.0-flash-thinking-exp`
-- `gemini-1.5-pro`, `gemini-1.5-pro-latest`
-- `gemini-1.5-flash`, `gemini-1.5-flash-latest`, `gemini-1.5-flash-8b`
-- `gemini-1.0-pro`
+- `gemini-3.5-flash`, `gemini-3.1-pro-preview`
+- `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.0-flash`
+- `gemini-1.5-pro`, `gemini-1.5-flash`, `gemini-1.5-flash-8b`
 
 ### `ollama(model, config?)`
 
@@ -179,14 +181,14 @@ Use `createProvider()` for type-safe provider creation:
 import { createProvider, anthropic, openai } from '@lov3kaizen/agentsea-core';
 
 // Generic factory
-const claudeProvider = createProvider(anthropic('claude-3-5-sonnet-20241022', { ... }));
+const claudeProvider = createProvider(anthropic('claude-opus-4-8', { ... }));
 const openaiProvider = createProvider(openai('gpt-4o', { ... }));
 
 // Provider-specific factories (for explicit typing)
 import { createAnthropicProvider, createOpenAIProvider } from '@lov3kaizen/agentsea-core';
 
 const claude = createAnthropicProvider(
-  anthropic('claude-3-5-sonnet-20241022', { ... }),
+  anthropic('claude-opus-4-8', { ... }),
   { apiKey: process.env.ANTHROPIC_API_KEY }
 );
 ```
@@ -247,7 +249,7 @@ const thinkingModels = getModelsWithCapability('extendedThinking', true);
 ### Using Provider Capabilities
 
 ```typescript
-const provider = createProvider(anthropic('claude-3-5-sonnet-20241022', { ... }));
+const provider = createProvider(anthropic('claude-opus-4-8', { ... }));
 
 // Check capabilities on the provider
 if (provider.supportsCapability('tools')) {
@@ -260,6 +262,8 @@ console.log(`Context window: ${info?.capabilities.contextWindow}`);
 ```
 
 ## Model Capability Reference
+
+> The tables below are illustrative. The latest models — Claude Opus 4.6–4.8, Sonnet 4.6, Fable 5; GPT-5.x and o3; Gemini 2.5/3.x — are in the registry; call `getModelInfo(model)` for exact, up-to-date capabilities, context window, and max output.
 
 ### Anthropic Models
 

--- a/docs/PER_MODEL_TYPE_SAFETY.md
+++ b/docs/PER_MODEL_TYPE_SAFETY.md
@@ -121,12 +121,14 @@ const o3MiniConfig = openai('o3-mini', {
 });
 ```
 
-**Supported Models (latest first):**
+**Typed models (latest first):**
 
-- `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.2` (+ `pro`/`codex`), `gpt-5.1` (+ `codex` variants)
+- `gpt-5.2` (+ `pro`/`codex`), `gpt-5.1` (+ `codex` variants)
 - `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-pro`, `gpt-4.1`
 - `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`, `gpt-4`, `gpt-3.5-turbo`
 - Reasoning: `o3`, `o3-pro`, `o3-mini`, `o1`, `o1-mini`
+
+> Even newer models (e.g. `gpt-5.5`, `gpt-5.4-mini`) are accepted at runtime via the plain string `model` field and priced in the [costs](../packages/costs) registry; they're added to the typed builder above as the type registry catches up.
 
 ### `gemini(model, config?)`
 
@@ -150,11 +152,12 @@ const geminiConfig = gemini('gemini-1.5-pro', {
 });
 ```
 
-**Supported Models (latest first):**
+**Typed models (latest first):**
 
-- `gemini-3.5-flash`, `gemini-3.1-pro-preview`
 - `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.0-flash`
 - `gemini-1.5-pro`, `gemini-1.5-flash`, `gemini-1.5-flash-8b`
+
+> Newer Gemini releases (e.g. `gemini-3.5-flash`, `gemini-3.1-pro-preview`) are accepted at runtime via the string `model` field and priced in the [costs](../packages/costs) registry, ahead of the typed builder.
 
 ### `ollama(model, config?)`
 
@@ -263,7 +266,7 @@ console.log(`Context window: ${info?.capabilities.contextWindow}`);
 
 ## Model Capability Reference
 
-> The tables below are illustrative. The latest models — Claude Opus 4.6–4.8, Sonnet 4.6, Fable 5; GPT-5.x and o3; Gemini 2.5/3.x — are in the registry; call `getModelInfo(model)` for exact, up-to-date capabilities, context window, and max output.
+> The tables below are illustrative. The latest typed models — Claude Opus 4.6–4.8, Sonnet 4.6, Fable 5; GPT-5.1/5.2 and o3; Gemini 2.5 — are in the registry; call `getModelInfo(model)` for exact, up-to-date capabilities, context window, and max output.
 
 ### Anthropic Models
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -44,19 +44,21 @@ const provider = new AnthropicProvider(process.env.ANTHROPIC_API_KEY);
 
 const agent = new Agent({
   name: 'claude-agent',
-  model: 'claude-sonnet-4-20250514',
+  model: 'claude-opus-4-8',
   provider: 'anthropic',
 });
 
 agent.registerProvider('anthropic', provider);
 ```
 
-**Available Models:**
+**Available Models (latest):**
 
-- `claude-sonnet-4-20250514` - Most capable
-- `claude-3-5-sonnet-20241022` - Fast and capable
-- `claude-3-opus-20240229` - Previous flagship
-- `claude-3-haiku-20240307` - Fast and cost-effective
+- `claude-opus-4-8` - Most capable (default); also `claude-opus-4-7`, `claude-opus-4-6`
+- `claude-sonnet-4-6` - Balanced speed and quality
+- `claude-haiku-4-5` - Fast and cost-effective
+- `claude-fable-5` - Most advanced reasoning
+
+Older generations (Claude 3.x, Sonnet/Opus 4.0–4.5) remain supported.
 
 **Features:**
 
@@ -80,18 +82,19 @@ const provider = new OpenAIProvider(process.env.OPENAI_API_KEY);
 
 const agent = new Agent({
   name: 'gpt-agent',
-  model: 'gpt-4-turbo-preview',
+  model: 'gpt-5.5',
   provider: 'openai',
 });
 
 agent.registerProvider('openai', provider);
 ```
 
-**Available Models:**
+**Available Models (latest):**
 
-- `gpt-4-turbo-preview` - Most capable
-- `gpt-4` - Stable GPT-4
-- `gpt-3.5-turbo` - Fast and cost-effective
+- `gpt-5.5` - Most capable; also `gpt-5.2` (+ `pro`/`codex`), `gpt-5.1`
+- `gpt-5.4-mini` - Fast and cost-effective
+- `o3`, `o1` - Reasoning models
+- `gpt-4.1`, `gpt-4o` - Previous generation
 
 **Features:**
 
@@ -115,24 +118,25 @@ const provider = new GeminiProvider(process.env.GEMINI_API_KEY);
 
 const agent = new Agent({
   name: 'gemini-agent',
-  model: 'gemini-pro',
+  model: 'gemini-2.5-pro',
   provider: 'gemini',
 });
 
 agent.registerProvider('gemini', provider);
 ```
 
-**Available Models:**
+**Available Models (latest):**
 
-- `gemini-pro` - Most capable
-- `gemini-pro-vision` - With vision capabilities
+- `gemini-3.5-flash`, `gemini-3.1-pro-preview` - Newest generation
+- `gemini-2.5-pro` - Most capable stable
+- `gemini-2.5-flash`, `gemini-2.0-flash` - Fast and cost-effective
 
 **Features:**
 
 - ✅ Tool calling
 - ✅ Streaming
 - ✅ System prompts
-- ✅ Vision (gemini-pro-vision)
+- ✅ Vision (multimodal models)
 
 **Environment Variables:**
 
@@ -522,13 +526,13 @@ const provider = new OllamaProvider({
 ```typescript
 // Fast, cheap queries - use smaller models
 const quickAgent = new Agent({
-  model: 'claude-3-haiku-20240307',
+  model: 'claude-haiku-4-5',
   provider: 'anthropic',
 });
 
 // Complex, important queries - use larger models
 const smartAgent = new Agent({
-  model: 'claude-sonnet-4-20250514',
+  model: 'claude-opus-4-8',
   provider: 'anthropic',
 });
 ```

--- a/docs/VOICE.md
+++ b/docs/VOICE.md
@@ -361,7 +361,7 @@ const toolRegistry = new ToolRegistry();
 const agent = new Agent(
   {
     name: 'voice-assistant',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-opus-4-8',
     provider: 'anthropic',
     systemPrompt: 'You are a helpful voice assistant.',
     description: 'Voice assistant',
@@ -497,7 +497,7 @@ voiceAgent.setAutoSpeak(false);
 const agent = new Agent(
   {
     name: 'customer-service',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-opus-4-8',
     provider: 'anthropic',
     systemPrompt: 'You are a helpful customer service representative.',
     description: 'Customer service bot',
@@ -522,7 +522,7 @@ const result = await voiceAgent.processVoice(customerAudio, context);
 const agent = new Agent(
   {
     name: 'language-tutor',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-opus-4-8',
     provider: 'anthropic',
     systemPrompt: 'You are a Spanish language tutor.',
     description: 'Language tutor',
@@ -548,7 +548,7 @@ const result = await voiceAgent.processVoice(studentAudio, context);
 const agent = new Agent(
   {
     name: 'podcast-host',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-opus-4-8',
     provider: 'anthropic',
     systemPrompt: 'You are an engaging podcast host.',
     description: 'Podcast host',


### PR DESCRIPTION
## Summary

Documentation refresh: update the README and all guides to the latest models and current feature surface, keep the README concise, and add an exploration of integration orchestrators (Nango / Composio).

## Models (grounded in the repo's registries)

- **README** now has a dedicated **Supported Models** section and uses current IDs everywhere (default `claude-opus-4-8`). Runtime "latest" reflects the costs registry: Claude Opus 4.8/4.7/4.6, Sonnet 4.6, Haiku 4.5, Fable 5; GPT-5.5/5.4-mini/5.2/o3; Gemini 3.5-flash/3.1-pro-preview/2.5.
- **PROVIDERS.md** — refreshed per-provider examples and "available models" lists.
- **PER_MODEL_TYPE_SAFETY.md** — modernized primary examples (adaptive vs. explicit extended thinking) and **scoped the typed-builder lists to the type registry** (up to `gpt-5.2`/`gemini-2.5`), with a note that newer models work at runtime via the string `model` field. Kept `o1`/`o1-mini`/`gpt-4o` as capability-teaching examples.
- **QUICK_START / API / CLI / FORMATTING / VOICE / ACP** — example model IDs updated to current.
- Historical release notes intentionally left untouched.

## Conciseness

- Tightened the README and condensed the duplicative **Core Concepts** prose into a compact table.

## New: integration-orchestrators exploration

`docs/integrations-orchestrators.md` — a decision-oriented RFC on adding **Nango** / **Composio** support:

- The gap they fill (managed per-user OAuth + a large tool/action catalog + live SaaS data for RAG) that AgentSea doesn't have today.
- How they map onto existing seams — the MCP `tool-adapter` (JSON Schema → `Tool`) and `sse` transport mean Composio's hosted MCP server can be consumed with near-zero code, and Nango syncs can feed `ingest`/`memory`.
- Benefits, trade-offs (vendor coupling, data egress, MCP overlap), and a phased recommendation behind a single `Connector` abstraction.

## Notes

- No code changes; docs only. A pre-existing registry inconsistency is surfaced (the **costs** registry has `gpt-5.5`/`gemini-3.x` but the **types** registry stops at `gpt-5.2`/`gemini-2.5`); the docs now describe both layers accurately rather than papering over it.
