### PR TITLE
test(surf): stop browser smoke teardown from hanging CI

### DIFF
--- a/packages/surf/src/__tests__/playwright-smoke.test.ts
+++ b/packages/surf/src/__tests__/playwright-smoke.test.ts
@@ -22,32 +22,48 @@ let backend: PlaywrightBackend | null = null;
 let browserAvailable = false;
 let skipReason = '';
 
+/**
+ * Disconnect without ever hanging: a wedged/partially-launched browser can make
+ * disconnect() stall, which would otherwise trip the hook timeout. Bound it.
+ */
+async function boundedDisconnect(b: PlaywrightBackend): Promise<void> {
+  await Promise.race([
+    b.disconnect().catch(() => {}),
+    new Promise<void>((resolve) => setTimeout(resolve, 8000)),
+  ]);
+}
+
 beforeAll(async () => {
   if (FORCE_SKIP) {
     skipReason = 'SURF_SKIP_PLAYWRIGHT=1';
     return;
   }
+  let b: PlaywrightBackend | null = null;
   try {
-    const b = new PlaywrightBackend({ headless: true });
+    b = new PlaywrightBackend({ headless: true });
     await b.connect();
     backend = b;
     browserAvailable = true;
   } catch (err) {
     skipReason = err instanceof Error ? err.message : String(err);
     browserAvailable = false;
-    if (backend) {
-      await backend.disconnect().catch(() => {});
-      backend = null;
+    // A failed launch may still have spawned a browser process; tear down the
+    // local instance (not the never-assigned `backend`) so no handle lingers
+    // and stalls the afterAll teardown.
+    if (b) {
+      await boundedDisconnect(b);
     }
+    backend = null;
   }
 }, 60_000);
 
 afterAll(async () => {
-  if (backend) {
-    await backend.disconnect().catch(() => {});
-    backend = null;
+  const b = backend;
+  backend = null;
+  if (b) {
+    await boundedDisconnect(b);
   }
-});
+}, 30_000);
 
 describe('PlaywrightBackend headless smoke', () => {
   it('reports whether a browser was available (always runs)', () => {

--- a/packages/surf/src/__tests__/puppeteer-smoke.test.ts
+++ b/packages/surf/src/__tests__/puppeteer-smoke.test.ts
@@ -23,13 +23,25 @@ let backend: PuppeteerBackend | null = null;
 let browserAvailable = false;
 let skipReason = '';
 
+/**
+ * Disconnect without ever hanging: a wedged/partially-launched browser can make
+ * disconnect() stall, which would otherwise trip the hook timeout. Bound it.
+ */
+async function boundedDisconnect(b: PuppeteerBackend): Promise<void> {
+  await Promise.race([
+    b.disconnect().catch(() => {}),
+    new Promise<void>((resolve) => setTimeout(resolve, 8000)),
+  ]);
+}
+
 beforeAll(async () => {
   if (FORCE_SKIP) {
     skipReason = 'SURF_SKIP_PUPPETEER=1';
     return;
   }
+  let b: PuppeteerBackend | null = null;
   try {
-    const b = new PuppeteerBackend({ headless: true });
+    b = new PuppeteerBackend({ headless: true });
     // connect() dynamically imports puppeteer-core and launches the browser.
     // Any failure (missing module, no executable, launch error) lands here.
     await b.connect();
@@ -38,19 +50,23 @@ beforeAll(async () => {
   } catch (err) {
     skipReason = err instanceof Error ? err.message : String(err);
     browserAvailable = false;
-    if (backend) {
-      await backend.disconnect().catch(() => {});
-      backend = null;
+    // A failed launch may still have spawned a browser process; tear down the
+    // local instance (not the never-assigned `backend`) so no handle lingers
+    // and stalls the afterAll teardown.
+    if (b) {
+      await boundedDisconnect(b);
     }
+    backend = null;
   }
 }, 60_000);
 
 afterAll(async () => {
-  if (backend) {
-    await backend.disconnect().catch(() => {});
-    backend = null;
+  const b = backend;
+  backend = null;
+  if (b) {
+    await boundedDisconnect(b);
   }
-});
+}, 30_000);
 
 describe('PuppeteerBackend headless smoke', () => {
   it('reports whether a browser was available (always runs)', () => {


### PR DESCRIPTION
## Problem

The surf `puppeteer-smoke` / `playwright-smoke` tests launch a real headless browser and are meant to skip gracefully when none is installed (as in CI). But when `connect()` failed, the catch block disconnected `backend` — still `null` at that point — instead of the local instance `b` that may have spawned a browser process. That lingering handle stalled the `afterAll` teardown past the default 10s hook timeout, failing the suite (seen on PR #45 CI; unrelated to that PR's changes).

## Fix

- Tear down the **local** instance on a failed launch (not the never-assigned `backend`).
- Bound `disconnect()` with an 8s race so a wedged browser can't hang teardown.
- Give `afterAll` an explicit 30s timeout.
- Applied to both smoke tests (same latent bug).

## Verification

- `pnpm --filter @lov3kaizen/agentsea-surf test` — 16 files pass, 444 passed / 6 skipped.
- With no browser available (the CI scenario), both smoke suites now **skip and tear down in ~200ms** instead of timing out.

This is an environment/flaky-test robustness fix; merging it unblocks CI on the other open PRs (#44, #45).