### PR TITLE
chore: release 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentsea",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "AgentSea - Production-ready ADK for building agentic AI applications in Node.js",
   "keywords": [

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-admin-ui
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-admin-ui",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/analytics/CHANGELOG.md
+++ b/packages/analytics/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-analytics
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-analytics",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/cache/CHANGELOG.md
+++ b/packages/cache/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-cache
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-cache",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Semantic caching layer for LLM responses - exact match, semantic similarity, and hybrid strategies",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-cli
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "CLI tool for AgentSea ADK - Build and orchestrate AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-core
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-core",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "AgentSea - Unite and orchestrate AI agents. A production-ready ADK for building agentic AI applications with multi-provider support.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/costs/CHANGELOG.md
+++ b/packages/costs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-costs
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/costs/package.json
+++ b/packages/costs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-costs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/crews/CHANGELOG.md
+++ b/packages/crews/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-crews
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/crews/package.json
+++ b/packages/crews/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-crews",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Multi-agent orchestration framework for AgentSea. Build, compose, and orchestrate agent crews with role-based coordination, task delegation, and workflow automation.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/debugger/CHANGELOG.md
+++ b/packages/debugger/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-debugger
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-debugger",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "AI Agent debugger with step-through execution, decision tree visualization, checkpoint replay, and what-if scenario testing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-e2e
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-e2e",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "Cross-package end-to-end tests wiring AgentSea packages together as a user would.",
   "type": "module",

--- a/packages/embeddings/CHANGELOG.md
+++ b/packages/embeddings/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-embeddings
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/embeddings/package.json
+++ b/packages/embeddings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-embeddings",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Vector embedding lifecycle management toolkit for Node.js - versioning, caching, chunking, drift detection, and migration",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/evaluate/CHANGELOG.md
+++ b/packages/evaluate/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-evaluate
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/evaluate/package.json
+++ b/packages/evaluate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-evaluate",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Comprehensive feedback collection and LLM evaluation platform for Node.js - human-in-the-loop annotation, automated evaluation pipelines, preference dataset generation",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/gateway/CHANGELOG.md
+++ b/packages/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-gateway
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-gateway",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "High-performance TypeScript-native LLM gateway with unified API access, intelligent routing, semantic caching, and cost optimization",
   "keywords": [
     "llm",

--- a/packages/guardrails/CHANGELOG.md
+++ b/packages/guardrails/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-guardrails
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/guardrails/package.json
+++ b/packages/guardrails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-guardrails",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "TypeScript-native guardrails engine for AI applications. Content safety, prompt injection detection, output validation, and intelligent rate limiting.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/ingest/CHANGELOG.md
+++ b/packages/ingest/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-ingest
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/ingest/package.json
+++ b/packages/ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-ingest",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/memory/CHANGELOG.md
+++ b/packages/memory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-memory
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-memory",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/nestjs/CHANGELOG.md
+++ b/packages/nestjs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-nestjs
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-nestjs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/prompts/CHANGELOG.md
+++ b/packages/prompts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-prompts
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-prompts",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-react
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-react",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "React components for rendering AgentSea agent responses with formatting support",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/redteam/CHANGELOG.md
+++ b/packages/redteam/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-redteam
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/redteam/package.json
+++ b/packages/redteam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-redteam",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/structured/CHANGELOG.md
+++ b/packages/structured/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-structured
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/structured/package.json
+++ b/packages/structured/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-structured",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/surf/CHANGELOG.md
+++ b/packages/surf/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-surf
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/surf/package.json
+++ b/packages/surf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-surf",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Surf - Computer-use agent for AgentSea. Control desktop environments through screen capture, mouse, and keyboard actions using Claude's vision capabilities.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @lov3kaizen/agentsea-types
 
+## 1.2.1
+
+- Bump for monorepo version consistency.
+
 ## 1.2.0
 
 - Bump for monorepo version consistency.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lov3kaizen/agentsea-types",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Type definitions for AgentSea ADK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Release 1.2.1 (patch)

Lockstep bump of all 22 packages + root from **1.2.0 → 1.2.1**.

### Included since 1.2.0

- **#46** `test(surf)` — stop the browser smoke-test teardown from hanging CI when no browser is installed.
- **#45** `fix(types,costs)` — reconcile the model registries (frontier models `gpt-5.5`/`gpt-5.4-mini`/`gemini-3.x` now typed; `gemini-2.0-flash-exp` priced; parity between `getModelInfo` and the pricing registry).
- **#44** `docs` — refresh README + guides to the latest models; concise pass.

No source/behavioral changes beyond the above; patch-level.

### After merge

Tag `v1.2.1` to trigger the release workflow (npm publish + GitHub Release):

```
git checkout main && git pull
git tag -a v1.2.1 -m "Release 1.2.1" && git push origin v1.2.1
```

### Verification

- `pnpm install --frozen-lockfile` ✅ (lockfile unchanged by the version bump)
- Full build + test suite were green across all packages on the merged branches.